### PR TITLE
로그인, 회원가입 e2e 테스트 작성

### DIFF
--- a/src/main/java/com/fanfixiv/auth/controller/LoginController.java
+++ b/src/main/java/com/fanfixiv/auth/controller/LoginController.java
@@ -5,7 +5,6 @@ import com.fanfixiv.auth.dto.login.LoginDto;
 import com.fanfixiv.auth.dto.login.LoginResultDto;
 import com.fanfixiv.auth.dto.profile.ProfileResultDto;
 import com.fanfixiv.auth.service.LoginService;
-import java.security.Principal;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +38,7 @@ public class LoginController {
   }
 
   @GetMapping("/profile")
-  public ProfileResultDto profile(@AuthenticationPrincipal User user, Principal principal)
+  public ProfileResultDto profile(@AuthenticationPrincipal User user)
       throws Exception {
     return new ProfileResultDto(user.getUser());
   }

--- a/src/test/java/com/fanfixiv/auth/AuthE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/AuthE2ETests.java
@@ -42,6 +42,9 @@ public class AuthE2ETests {
   @Test
   @DisplayName("H2 데이터 베이스 테스트")
   void h2test() {
+
+    profileRepository.deleteAll();
+
     ProfileEntity _p = ProfileEntity.builder().nickname("테스트").descript("테스트입니다.").build();
 
     profileRepository.save(_p);

--- a/src/test/java/com/fanfixiv/auth/LoginE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/LoginE2ETests.java
@@ -134,7 +134,7 @@ public class LoginE2ETests {
   }
 
   @Test
-  @DisplayName("POST /profile 200")
+  @DisplayName("GET /profile 200")
   void getUserProfile_e2e_200() {
     ProfileResultDto actual = new ProfileResultDto(LoginE2ETests.user);
     given()
@@ -151,7 +151,7 @@ public class LoginE2ETests {
   }
 
   @Test
-  @DisplayName("POST /profile 401")
+  @DisplayName("GET /profile 401")
   void getUserProfile_e2e_401() {
     given()
         .contentType("application/json")

--- a/src/test/java/com/fanfixiv/auth/LoginE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/LoginE2ETests.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import com.fanfixiv.auth.dto.login.LoginDto;
@@ -139,7 +140,7 @@ public class LoginE2ETests {
     ProfileResultDto actual = new ProfileResultDto(LoginE2ETests.user);
     given()
         .contentType("application/json")
-        .header("Authorization", "Bearer " + LoginE2ETests.access_token)
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + LoginE2ETests.access_token)
         .get("/profile")
         .then()
         .statusCode(200)
@@ -155,7 +156,6 @@ public class LoginE2ETests {
   void getUserProfile_e2e_401() {
     given()
         .contentType("application/json")
-        .header("Authorization", "Bearer testjwttoken")
         .post("/profile")
         .then()
         .statusCode(401);

--- a/src/test/java/com/fanfixiv/auth/LoginE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/LoginE2ETests.java
@@ -1,0 +1,164 @@
+package com.fanfixiv.auth;
+
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import com.fanfixiv.auth.dto.login.LoginDto;
+import com.fanfixiv.auth.dto.profile.ProfileResultDto;
+import com.fanfixiv.auth.entity.ProfileEntity;
+import com.fanfixiv.auth.entity.UserEntity;
+import com.fanfixiv.auth.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class LoginE2ETests {
+
+  @Autowired
+  UserRepository userRepository;
+
+  @Autowired
+  BCryptPasswordEncoder passwordEncoder;
+
+  @LocalServerPort
+  private int _port;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    port = _port;
+  }
+
+  ObjectMapper objectMapper = new ObjectMapper();
+
+  static String access_token = "";
+  static String refresh_token = "";
+
+  static UserEntity user;
+
+  private String objToJson(Object obj) {
+    try {
+      return this.objectMapper.writeValueAsString(obj);
+    } catch (Exception e) {
+      return "";
+    }
+  }
+
+  @Test
+  @DisplayName("POST /login 200")
+  void doLogin_e2e_200() {
+
+    String email = "test@example.com";
+    String pw = "password";
+
+    ProfileEntity profile = ProfileEntity.builder()
+        .nickname("테스트계정")
+        .birth(LocalDate.of(2002, 8, 19))
+        .build();
+
+    LoginE2ETests.user = UserEntity.builder()
+        .email(email)
+        .pw(pw)
+        .profile(profile)
+        .build();
+
+    user.hashPassword(passwordEncoder);
+
+    userRepository.save(user);
+
+    LoginDto lgdto = new LoginDto();
+
+    lgdto.setId(email);
+    lgdto.setPw(pw);
+
+    ExtractableResponse<Response> res = given()
+        .contentType("application/json")
+        .body(
+            this.objToJson(lgdto))
+        .post("/login")
+        .then()
+        .statusCode(200)
+        .extract();
+
+    LoginE2ETests.refresh_token = res.header("Set-Cookie");
+    LoginE2ETests.access_token = res.path("token");
+  }
+
+  @Test
+  @DisplayName("POST /login 401")
+  void doLogin_e2e_401() {
+
+    String email = "test@example.com";
+    String pw = "not_password";
+
+    LoginDto lgdto = new LoginDto();
+
+    lgdto.setId(email);
+    lgdto.setPw(pw);
+
+    given()
+        .contentType("application/json")
+        .body(this.objToJson(lgdto))
+        .post("/login")
+        .then()
+        .statusCode(401);
+  }
+
+  @Test
+  @DisplayName("POST /login 400")
+  void doLogin_e2e_400() {
+
+    String email = "test@example.com";
+
+    LoginDto lgdto = new LoginDto();
+
+    lgdto.setId(email);
+
+    given()
+        .contentType("application/json")
+        .body(this.objToJson(lgdto))
+        .post("/login")
+        .then()
+        .statusCode(400);
+  }
+
+  @Test
+  @DisplayName("POST /profile 200")
+  void getUserProfile_e2e_200() {
+    ProfileResultDto actual = new ProfileResultDto(LoginE2ETests.user);
+    given()
+        .contentType("application/json")
+        .header("Authorization", "Bearer " + LoginE2ETests.access_token)
+        .get("/profile")
+        .then()
+        .statusCode(200)
+        .assertThat()
+        .body("email", equalTo(actual.getEmail()))
+        .body("nickname", equalTo(actual.getNickname()))
+        .body("birth", equalTo(actual.getBirth().toString()))
+        .body("descript", equalTo(actual.getDescript()));
+  }
+
+  @Test
+  @DisplayName("POST /profile 401")
+  void getUserProfile_e2e_401() {
+    given()
+        .contentType("application/json")
+        .header("Authorization", "Bearer testjwttoken")
+        .post("/profile")
+        .then()
+        .statusCode(401);
+  }
+
+}

--- a/src/test/java/com/fanfixiv/auth/RegisterE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/RegisterE2ETests.java
@@ -42,7 +42,7 @@ public class RegisterE2ETests {
         .then()
         .statusCode(200)
         .assertThat()
-        .body("canUse", equalTo(true));
+        .body("can_use", equalTo(true));
 
     profileRepository.save(
         ProfileEntity.builder()
@@ -55,7 +55,7 @@ public class RegisterE2ETests {
         .then()
         .statusCode(200)
         .assertThat()
-        .body("canUse", equalTo(false));
+        .body("can_use", equalTo(false));
 
   }
 

--- a/src/test/java/com/fanfixiv/auth/RegisterE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/RegisterE2ETests.java
@@ -1,0 +1,159 @@
+package com.fanfixiv.auth;
+
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doAnswer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import com.fanfixiv.auth.entity.ProfileEntity;
+import com.fanfixiv.auth.repository.ProfileRepository;
+import com.fanfixiv.auth.service.MailService;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class RegisterE2ETests {
+
+  @Autowired
+  ProfileRepository profileRepository;
+
+  @LocalServerPort
+  private int _port;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    port = _port;
+  }
+
+  @Test
+  @DisplayName("GET /register/dc-nick 200")
+  void isNickDouble_e2e_200() {
+    given()
+        .param("nickname", "test1")
+        .get("/register/dc-nick")
+        .then()
+        .statusCode(200)
+        .assertThat()
+        .body("canUse", equalTo(true));
+
+    profileRepository.save(
+        ProfileEntity.builder()
+            .nickname("test1")
+            .build());
+
+    given()
+        .param("nickname", "test1")
+        .get("/register/dc-nick")
+        .then()
+        .statusCode(200)
+        .assertThat()
+        .body("canUse", equalTo(false));
+
+  }
+
+  @Test
+  @DisplayName("GET /register/dc-nick 400")
+  void isNickDouble_e2e_400() {
+    given()
+        .get("/register/dc-nick")
+        .then()
+        .statusCode(400);
+  }
+
+  // ===
+
+  @MockBean
+  MailService mailService;
+
+  static String uuid = "";
+  static String num = "";
+
+  @Test
+  @DisplayName("GET /register/cert-email 200")
+  void certEmail_e2e_200() {
+    
+    doAnswer(
+      new Answer<Object>() {
+      public Object answer(InvocationOnMock invocation) {
+          RegisterE2ETests.num = (String)invocation.getArgument(1);
+          return null;
+      }})
+    .when(mailService)
+    .sendMail(anyString(), anyString(), anyList());
+    
+    RegisterE2ETests.uuid = given()
+        .param("email", "test@example.com")
+        .get("/register/cert-email")
+        .then()
+        .statusCode(200)
+        .extract()
+        .path("uuid");
+  }
+
+  @Test
+  @DisplayName("GET /register/cert-email 400")
+  void certEmail_e2e_400() {
+    given()
+        .get("/register/cert-email")
+        .then()
+        .statusCode(400);
+  }
+
+  // ===
+
+  @Test
+  @DisplayName("GET /register/cert-number 200")
+  void certNumber_e2e_200() {
+
+    given()
+        .param("uuid",
+            RegisterE2ETests.uuid)
+        .param("number",
+            RegisterE2ETests.num)
+        .get("/register/cert-number")
+        .then()
+        .statusCode(200)
+        .assertThat()
+        .body("success", equalTo(true));
+
+    given()
+        .param("uuid",
+            "testuuid-1234")
+        .param("number",
+            "1234")
+        .get("/register/cert-number")
+        .then()
+        .statusCode(200)
+        .assertThat()
+        .body("success", equalTo(false));
+  }
+
+  @Test
+  @DisplayName("GET /register/cert-number 400")
+  void certNumber_e2e_400() {
+    given()
+        .get("/register/cert-email")
+        .then()
+        .statusCode(400);
+    given()
+        .param("number",
+            "1234")
+        .get("/register/cert-email")
+        .then()
+        .statusCode(400);
+    given()
+        .param("uuid",
+            "testuuid-1234")
+        .get("/register/cert-email")
+        .then()
+        .statusCode(400);
+  }
+}


### PR DESCRIPTION
> #13 참고

**PR 설명**
로그인, 회원가입 관련 API의 e2e 테스트를 추가하였습니다.

**개발된 기능**
- `POST /login 200` 테스트
- `POST /login 401` 테스트
- `POST /login 400` 테스트
- `GET /profile 200` 테스트
- `GET /profile 401` 테스트
- `GET /register/dc-nick 200` 테스트
- `GET /register/dc-nick 400` 테스트
- `GET /register/cert-email 200` 테스트
- `GET /register/cert-email 400` 테스트
- `GET /register/cert-number 200` 테스트
- `GET /register/cert-number 400` 테스트

**레퍼런스**
- https://rieckpil.de/testing-spring-boot-applications-with-rest-assured/
- https://rest-assured.io/