### PR TITLE
프로필 아이콘 업로드 API 연동

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -40,4 +40,6 @@ jobs:
         env:
           AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          MAIN_SERVER_URL: ${{ secrets.MAIN_SERVER_URL }}
           SECRET: ${{ secrets.SECRET }}
+          S3_URL: ${{ secrets.S3_URL }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -43,3 +43,4 @@ jobs:
           MAIN_SERVER_URL: ${{ secrets.MAIN_SERVER_URL }}
           SECRET: ${{ secrets.SECRET }}
           S3_URL: ${{ secrets.S3_URL }}
+          REDIS_HOST: 127.0.0.1

--- a/src/main/java/com/fanfixiv/auth/config/RedisConfig.java
+++ b/src/main/java/com/fanfixiv/auth/config/RedisConfig.java
@@ -5,7 +5,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableRedisRepositories // Redis Repository 활성화
@@ -20,5 +22,20 @@ public class RedisConfig {
   @Bean
   public RedisConnectionFactory redisConnectionFactory() {
     return new LettuceConnectionFactory(host, port);
+  }
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate() {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new StringRedisSerializer());
+    // Hash Operation 사용 시
+    redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+    redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+    redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+    return redisTemplate;
   }
 }

--- a/src/main/java/com/fanfixiv/auth/config/RestConfig.java
+++ b/src/main/java/com/fanfixiv/auth/config/RestConfig.java
@@ -1,0 +1,13 @@
+package com.fanfixiv.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestConfig {
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+}

--- a/src/main/java/com/fanfixiv/auth/controller/LoginController.java
+++ b/src/main/java/com/fanfixiv/auth/controller/LoginController.java
@@ -5,7 +5,6 @@ import com.fanfixiv.auth.dto.login.LoginDto;
 import com.fanfixiv.auth.dto.login.LoginResultDto;
 import com.fanfixiv.auth.dto.profile.ProfileResultDto;
 import com.fanfixiv.auth.service.LoginService;
-import java.security.Principal;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +38,7 @@ public class LoginController {
   }
 
   @GetMapping("/profile")
-  public ProfileResultDto profile(@AuthenticationPrincipal User user, Principal principal)
+  public ProfileResultDto profile(@AuthenticationPrincipal User user)
       throws Exception {
     return new ProfileResultDto(user.getUser());
   }

--- a/src/main/java/com/fanfixiv/auth/controller/advice/GlobalControllerAdvice.java
+++ b/src/main/java/com/fanfixiv/auth/controller/advice/GlobalControllerAdvice.java
@@ -28,11 +28,18 @@ public class GlobalControllerAdvice {
 
   @ExceptionHandler({
       MissingServletRequestParameterException.class,
-      DuplicateException.class,
-      MicroRequestException.class
+      DuplicateException.class
   })
   public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(Exception e) {
     ErrorResponse err = new ErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage());
+    return new ResponseEntity<ErrorResponse>(err, HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler({
+      MicroRequestException.class
+  })
+  public ResponseEntity<ErrorResponse> handleMissingMicroRequestException(MicroRequestException e) {
+    ErrorResponse err = new ErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage(), e.getDefaultMessage());
     return new ResponseEntity<ErrorResponse>(err, HttpStatus.BAD_REQUEST);
   }
 

--- a/src/main/java/com/fanfixiv/auth/controller/advice/GlobalControllerAdvice.java
+++ b/src/main/java/com/fanfixiv/auth/controller/advice/GlobalControllerAdvice.java
@@ -4,6 +4,8 @@ import com.fanfixiv.auth.controller.LoginController;
 import com.fanfixiv.auth.controller.RegisterController;
 import com.fanfixiv.auth.exception.DuplicateException;
 import com.fanfixiv.auth.exception.ErrorResponse;
+import com.fanfixiv.auth.exception.MicroRequestException;
+
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +26,11 @@ public class GlobalControllerAdvice {
     return new ResponseEntity<ErrorResponse>(err, HttpStatus.UNAUTHORIZED);
   }
 
-  @ExceptionHandler({ MissingServletRequestParameterException.class, DuplicateException.class })
+  @ExceptionHandler({
+      MissingServletRequestParameterException.class,
+      DuplicateException.class,
+      MicroRequestException.class
+  })
   public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(Exception e) {
     ErrorResponse err = new ErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage());
     return new ResponseEntity<ErrorResponse>(err, HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/fanfixiv/auth/dto/profile/ProfileResultDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/profile/ProfileResultDto.java
@@ -13,20 +13,20 @@ import lombok.Data;
 public class ProfileResultDto {
   private String email;
   private String nickname;
-  private LocalDateTime nn_md_date;
+  private LocalDateTime nnMdDate;
   private LocalDate birth;
-  private String profile_img;
+  private String profileImg;
   private String descript;
-  private boolean is_tr;
+  private boolean isTr;
 
   public ProfileResultDto(UserEntity user) {
     this.email = user.getEmail();
     this.nickname = user.getProfile().getNickname();
-    this.nn_md_date = user.getProfile().getNn_md_date();
+    this.nnMdDate = user.getProfile().getNnMdDate();
     this.birth = user.getProfile().getBirth();
-    this.profile_img = user.getProfile().getProfile_img();
+    this.profileImg = user.getProfile().getProfileImg();
     this.descript = user.getProfile().getDescript();
-    this.is_tr = user.getProfile().is_tr();
+    this.isTr = user.getProfile().isTr();
   }
 
 }

--- a/src/main/java/com/fanfixiv/auth/dto/register/DoubleCheckDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/register/DoubleCheckDto.java
@@ -6,5 +6,5 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class DoubleCheckDto {
-  private boolean can_use;
+  private boolean canUse;
 }

--- a/src/main/java/com/fanfixiv/auth/dto/register/RegisterDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/register/RegisterDto.java
@@ -21,4 +21,6 @@ public class RegisterDto {
 
   @NotEmpty
   private String uuid;
+
+  private String profileImg;
 }

--- a/src/main/java/com/fanfixiv/auth/dto/server/BaseResultFormDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/server/BaseResultFormDto.java
@@ -1,0 +1,9 @@
+package com.fanfixiv.auth.dto.server;
+
+import lombok.Getter;
+
+@Getter
+public class BaseResultFormDto {
+  private int status;
+  private String message;
+}

--- a/src/main/java/com/fanfixiv/auth/dto/server/ProfileFormDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/server/ProfileFormDto.java
@@ -9,4 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ProfileFormDto {
   private String key;
+  private String auth;
 }

--- a/src/main/java/com/fanfixiv/auth/dto/server/ProfileFormDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/server/ProfileFormDto.java
@@ -1,0 +1,12 @@
+package com.fanfixiv.auth.dto.server;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProfileFormDto {
+  private String key;
+}

--- a/src/main/java/com/fanfixiv/auth/dto/server/ProfileFormResultDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/server/ProfileFormResultDto.java
@@ -1,14 +1,10 @@
 package com.fanfixiv.auth.dto.server;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
-@Data
-@NoArgsConstructor
+@Getter
 @AllArgsConstructor
-public class ProfileFormResultDto {
-  private int status;
+public class ProfileFormResultDto extends BaseResultFormDto {
   private String key;
-  private String message;
 }

--- a/src/main/java/com/fanfixiv/auth/dto/server/ProfileFormResultDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/server/ProfileFormResultDto.java
@@ -1,0 +1,14 @@
+package com.fanfixiv.auth.dto.server;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProfileFormResultDto {
+  private int status;
+  private String key;
+  private String message;
+}

--- a/src/main/java/com/fanfixiv/auth/entity/ProfileEntity.java
+++ b/src/main/java/com/fanfixiv/auth/entity/ProfileEntity.java
@@ -27,18 +27,18 @@ public class ProfileEntity extends BaseEntity {
 
   @Column
   @ColumnDefault("now()")
-  private LocalDateTime nn_md_date;
+  private LocalDateTime nnMdDate;
 
   @Column
   private LocalDate birth;
 
   @Column
-  private String profile_img;
+  private String profileImg;
 
   @Column
   private String descript;
 
   @Column
   @ColumnDefault("false")
-  private boolean is_tr;
+  private boolean isTr;
 }

--- a/src/main/java/com/fanfixiv/auth/entity/RoleEntity.java
+++ b/src/main/java/com/fanfixiv/auth/entity/RoleEntity.java
@@ -25,8 +25,8 @@ import com.fanfixiv.auth.interfaces.UserRoleEnum;
 @Table(name = "tb_role")
 public class RoleEntity extends BaseEntity {
 
-  @Column()
-  private Long user_seq;
+  @Column(name = "user_seq")
+  private Long userSeq;
 
   @Enumerated(EnumType.STRING)
   @ColumnDefault(value = "'ROLE_USER'")

--- a/src/main/java/com/fanfixiv/auth/exception/MicroRequestException.java
+++ b/src/main/java/com/fanfixiv/auth/exception/MicroRequestException.java
@@ -1,0 +1,7 @@
+package com.fanfixiv.auth.exception;
+
+public class MicroRequestException extends RuntimeException {
+  public MicroRequestException(String msg) {
+    super(msg);
+  }
+}

--- a/src/main/java/com/fanfixiv/auth/exception/MicroRequestException.java
+++ b/src/main/java/com/fanfixiv/auth/exception/MicroRequestException.java
@@ -1,7 +1,16 @@
 package com.fanfixiv.auth.exception;
 
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
 public class MicroRequestException extends RuntimeException {
-  public MicroRequestException(String msg) {
+
+  private List<String> defaultMessage;
+
+  public MicroRequestException(String msg, List<String> defaultMessage) {
     super(msg);
+    this.defaultMessage = defaultMessage;
   }
 }

--- a/src/main/java/com/fanfixiv/auth/requester/RestRequester.java
+++ b/src/main/java/com/fanfixiv/auth/requester/RestRequester.java
@@ -1,7 +1,11 @@
 package com.fanfixiv.auth.requester;
 
+import java.util.ArrayList;
+
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import com.fanfixiv.auth.dto.server.ProfileFormDto;
@@ -22,19 +26,37 @@ public class RestRequester {
 
   private final RestTemplate restTemplate;
 
+  private final RedisTemplate<String, String> redisTemplate;
+
   public String uploadProfileImg(String key) {
     String uri = mainServerUrl + "profile-img/form"; // or any other uri
 
-    ProfileFormResultDto result = restTemplate.postForObject(
-        uri,
-        new ProfileFormDto(key),
-        ProfileFormResultDto.class);
+    ProfileFormResultDto result;
+    try {
+      result = restTemplate.postForObject(
+          uri,
+          new ProfileFormDto(key, redisTemplate.opsForValue().get("REDIS_AUTH")),
+          ProfileFormResultDto.class);
+    } catch (RestClientException e) {
+      throw new MicroRequestException(
+          "메인서버의 응답이 올바르지 않습니다.",
+          new ArrayList<String>() {
+            {
+              add(e.getMessage());
+            }
+          });
+    }
 
     if (result == null || result.getStatus() == 400)
-      throw new MicroRequestException("메인서버의 응답이 올바르지 않습니다.");
+      throw new MicroRequestException(
+          "메인서버의 응답이 올바르지 않습니다.",
+          result == null ? null : new ArrayList<String>() {
+            {
+              add(result.getMessage());
+            }
+          });
 
     return s3Url + result.getKey();
-
   }
 
 }

--- a/src/main/java/com/fanfixiv/auth/requester/RestRequester.java
+++ b/src/main/java/com/fanfixiv/auth/requester/RestRequester.java
@@ -1,0 +1,40 @@
+package com.fanfixiv.auth.requester;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import com.fanfixiv.auth.dto.server.ProfileFormDto;
+import com.fanfixiv.auth.dto.server.ProfileFormResultDto;
+import com.fanfixiv.auth.exception.MicroRequestException;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RestRequester {
+
+  @Value("${micro.main-server.url}")
+  private String mainServerUrl;
+
+  @Value("${aws.s3.url}")
+  private String s3Url;
+
+  private final RestTemplate restTemplate;
+
+  public String uploadProfileImg(String key) {
+    String uri = mainServerUrl + "profile-img/form"; // or any other uri
+
+    ProfileFormResultDto result = restTemplate.postForObject(
+        uri,
+        new ProfileFormDto(key),
+        ProfileFormResultDto.class);
+
+    if (result == null || result.getStatus() == 400)
+      throw new MicroRequestException("메인서버의 응답이 올바르지 않습니다.");
+
+    return s3Url + result.getKey();
+
+  }
+
+}

--- a/src/main/java/com/fanfixiv/auth/service/RegisterService.java
+++ b/src/main/java/com/fanfixiv/auth/service/RegisterService.java
@@ -8,8 +8,10 @@ import com.fanfixiv.auth.dto.register.DoubleCheckDto;
 import com.fanfixiv.auth.dto.register.RegisterDto;
 import com.fanfixiv.auth.dto.register.RegisterResultDto;
 import com.fanfixiv.auth.entity.ProfileEntity;
+import com.fanfixiv.auth.entity.RoleEntity;
 import com.fanfixiv.auth.entity.UserEntity;
 import com.fanfixiv.auth.exception.DuplicateException;
+import com.fanfixiv.auth.interfaces.UserRoleEnum;
 import com.fanfixiv.auth.repository.ProfileRepository;
 import com.fanfixiv.auth.repository.RedisEmailRepository;
 import com.fanfixiv.auth.repository.UserRepository;
@@ -63,7 +65,7 @@ public class RegisterService {
       throw new DuplicateException("이미 사용중인 이메일입니다.");
     }
     if (!redisDto.isSuccess()) {
-      new DuplicateException("본인인증이 되어있지 않습니다.");
+      throw new DuplicateException("본인인증이 되어있지 않습니다.");
     }
 
     String profileImgUrl = "";
@@ -84,6 +86,11 @@ public class RegisterService {
         .email(redisDto.getEmail())
         .pw(dto.getPw())
         .profile(profile)
+        .role(new ArrayList<RoleEntity>() {
+          {
+            add(RoleEntity.builder().role(UserRoleEnum.ROLE_USER).build());
+          }
+        })
         .build();
 
     user.hashPassword(passwordEncoder);

--- a/src/main/java/com/fanfixiv/auth/service/RegisterService.java
+++ b/src/main/java/com/fanfixiv/auth/service/RegisterService.java
@@ -13,6 +13,7 @@ import com.fanfixiv.auth.exception.DuplicateException;
 import com.fanfixiv.auth.repository.ProfileRepository;
 import com.fanfixiv.auth.repository.RedisEmailRepository;
 import com.fanfixiv.auth.repository.UserRepository;
+import com.fanfixiv.auth.requester.RestRequester;
 import com.fanfixiv.auth.utils.RandomProvider;
 import com.fanfixiv.auth.utils.TimeProvider;
 
@@ -45,6 +46,8 @@ public class RegisterService {
 
   private final BCryptPasswordEncoder passwordEncoder;
 
+  private final RestRequester restRequester;
+
   private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
   @Transactional
@@ -63,12 +66,18 @@ public class RegisterService {
       new DuplicateException("본인인증이 되어있지 않습니다.");
     }
 
+    String profileImgUrl = "";
+    if (dto.getProfileImg() != null) {
+      profileImgUrl = restRequester.uploadProfileImg(dto.getProfileImg());
+    }
+
     LocalDate birth = LocalDate.parse(dto.getBirth(), this.formatter);
 
     ProfileEntity profile = ProfileEntity.builder()
         .nickname(dto.getNickname())
-        .is_tr(false)
+        .isTr(false)
         .birth(birth)
+        .profileImg(profileImgUrl)
         .build();
 
     UserEntity user = UserEntity.builder()

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -24,6 +24,16 @@
       "name": "aws.ses.secret-key",
       "type": "java.lang.String",
       "description": "AWS 접근 키"
+    },
+    {
+      "name": "micro.main-server.url",
+      "type": "java.lang.String",
+      "description": "메인 서버 URL"
+    },
+    {
+      "name": "aws.s3.url",
+      "type": "java.lang.String",
+      "description": "s3 URL"
     }
   ]
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -6,6 +6,12 @@ spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
 aws.ses.access-key=${AWS_ACCESS_KEY}
 aws.ses.secret-key=${AWS_SECRET_KEY}
 
+aws.s3.url=${S3_URL}
+
+# microservice
+
+micro.main-server.url=${MAIN_SERVER_URL}
+
 # redis
 
 spring.redis.host=${REDIS_HOST}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -7,6 +7,12 @@ spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
 aws.ses.access-key=${AWS_ACCESS_KEY}
 aws.ses.secret-key=${AWS_SECRET_KEY}
 
+aws.s3.url=${S3_URL}
+
+# microservice
+
+micro.main-server.url=${MAIN_SERVER_URL}
+
 # redis
 
 spring.redis.host=${REDIS_HOST}

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -12,7 +12,7 @@ aws.s3.url=${S3_URL}
 micro.main-server.url=${MAIN_SERVER_URL}
 
 # redis
-spring.redis.host=127.0.0.1
+spring.redis.host=${REDIS_HOST}
 spring.redis.password=
 spring.redis.port=6379
 

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -5,6 +5,12 @@ spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
 aws.ses.access-key=${AWS_ACCESS_KEY}
 aws.ses.secret-key=${AWS_SECRET_KEY}
 
+aws.s3.url=${S3_URL}
+
+# microservice
+
+micro.main-server.url=${MAIN_SERVER_URL}
+
 # redis
 spring.redis.host=127.0.0.1
 spring.redis.password=

--- a/src/test/java/com/fanfixiv/auth/AuthE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/AuthE2ETests.java
@@ -19,9 +19,11 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class AuthE2ETests {
 
-  @Autowired private ProfileRepository profileRepository;
+  @Autowired
+  private ProfileRepository profileRepository;
 
-  @LocalServerPort private int _port;
+  @LocalServerPort
+  private int _port;
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -48,6 +50,6 @@ public class AuthE2ETests {
 
     ProfileEntity p = profileRepository.findAll().get(0);
 
-    assertEquals(_p.getNickname(), p.getNickname()); 
+    assertEquals(_p.getNickname(), p.getNickname());
   }
 }

--- a/src/test/java/com/fanfixiv/auth/AuthE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/AuthE2ETests.java
@@ -44,6 +44,9 @@ public class AuthE2ETests {
   @Test
   @DisplayName("H2 데이터 베이스 테스트")
   void h2test() {
+
+    profileRepository.deleteAll();
+
     ProfileEntity _p = ProfileEntity.builder().nickname("테스트").descript("테스트입니다.").build();
 
     profileRepository.save(_p);

--- a/src/test/java/com/fanfixiv/auth/LoginE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/LoginE2ETests.java
@@ -1,0 +1,164 @@
+package com.fanfixiv.auth;
+
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import com.fanfixiv.auth.dto.login.LoginDto;
+import com.fanfixiv.auth.dto.profile.ProfileResultDto;
+import com.fanfixiv.auth.entity.ProfileEntity;
+import com.fanfixiv.auth.entity.UserEntity;
+import com.fanfixiv.auth.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class LoginE2ETests {
+
+  @Autowired
+  UserRepository userRepository;
+
+  @Autowired
+  BCryptPasswordEncoder passwordEncoder;
+
+  @LocalServerPort
+  private int _port;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    port = _port;
+  }
+
+  ObjectMapper objectMapper = new ObjectMapper();
+
+  static String access_token = "";
+  static String refresh_token = "";
+
+  static UserEntity user;
+
+  private String objToJson(Object obj) {
+    try {
+      return this.objectMapper.writeValueAsString(obj);
+    } catch (Exception e) {
+      return "";
+    }
+  }
+
+  @Test
+  @DisplayName("POST /login 200")
+  void doLogin_e2e_200() {
+
+    String email = "test@example.com";
+    String pw = "password";
+
+    ProfileEntity profile = ProfileEntity.builder()
+        .nickname("테스트계정")
+        .birth(LocalDate.of(2002, 8, 19))
+        .build();
+
+    LoginE2ETests.user = UserEntity.builder()
+        .email(email)
+        .pw(pw)
+        .profile(profile)
+        .build();
+
+    user.hashPassword(passwordEncoder);
+
+    userRepository.save(user);
+
+    LoginDto lgdto = new LoginDto();
+
+    lgdto.setId(email);
+    lgdto.setPw(pw);
+
+    ExtractableResponse<Response> res = given()
+        .contentType("application/json")
+        .body(
+            this.objToJson(lgdto))
+        .post("/login")
+        .then()
+        .statusCode(200)
+        .extract();
+
+    LoginE2ETests.refresh_token = res.header("Set-Cookie");
+    LoginE2ETests.access_token = res.path("token");
+  }
+
+  @Test
+  @DisplayName("POST /login 401")
+  void doLogin_e2e_401() {
+
+    String email = "test@example.com";
+    String pw = "not_password";
+
+    LoginDto lgdto = new LoginDto();
+
+    lgdto.setId(email);
+    lgdto.setPw(pw);
+
+    given()
+        .contentType("application/json")
+        .body(this.objToJson(lgdto))
+        .post("/login")
+        .then()
+        .statusCode(401);
+  }
+
+  @Test
+  @DisplayName("POST /login 400")
+  void doLogin_e2e_400() {
+
+    String email = "test@example.com";
+
+    LoginDto lgdto = new LoginDto();
+
+    lgdto.setId(email);
+
+    given()
+        .contentType("application/json")
+        .body(this.objToJson(lgdto))
+        .post("/login")
+        .then()
+        .statusCode(400);
+  }
+
+  @Test
+  @DisplayName("GET /profile 200")
+  void getUserProfile_e2e_200() {
+    ProfileResultDto actual = new ProfileResultDto(LoginE2ETests.user);
+    given()
+        .contentType("application/json")
+        .header("Authorization", "Bearer " + LoginE2ETests.access_token)
+        .get("/profile")
+        .then()
+        .statusCode(200)
+        .assertThat()
+        .body("email", equalTo(actual.getEmail()))
+        .body("nickname", equalTo(actual.getNickname()))
+        .body("birth", equalTo(actual.getBirth().toString()))
+        .body("descript", equalTo(actual.getDescript()));
+  }
+
+  @Test
+  @DisplayName("GET /profile 401")
+  void getUserProfile_e2e_401() {
+    given()
+        .contentType("application/json")
+        .header("Authorization", "Bearer testjwttoken")
+        .post("/profile")
+        .then()
+        .statusCode(401);
+  }
+
+}

--- a/src/test/java/com/fanfixiv/auth/LoginE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/LoginE2ETests.java
@@ -7,7 +7,10 @@ import java.time.LocalDate;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -23,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class LoginE2ETests {
 
@@ -56,14 +60,16 @@ public class LoginE2ETests {
   }
 
   @Test
+  @Order(1)
   @DisplayName("POST /login 200")
   void doLogin_e2e_200() {
 
     String email = "test@example.com";
     String pw = "password";
+    String nick = "테스트계정";
 
     ProfileEntity profile = ProfileEntity.builder()
-        .nickname("테스트계정")
+        .nickname(nick)
         .birth(LocalDate.of(2002, 8, 19))
         .build();
 
@@ -84,8 +90,7 @@ public class LoginE2ETests {
 
     ExtractableResponse<Response> res = given()
         .contentType("application/json")
-        .body(
-            this.objToJson(lgdto))
+        .body(this.objToJson(lgdto))
         .post("/login")
         .then()
         .statusCode(200)
@@ -96,6 +101,7 @@ public class LoginE2ETests {
   }
 
   @Test
+  @Order(1)
   @DisplayName("POST /login 401")
   void doLogin_e2e_401() {
 
@@ -116,6 +122,7 @@ public class LoginE2ETests {
   }
 
   @Test
+  @Order(1)
   @DisplayName("POST /login 400")
   void doLogin_e2e_400() {
 
@@ -134,6 +141,7 @@ public class LoginE2ETests {
   }
 
   @Test
+  @Order(2)
   @DisplayName("GET /profile 200")
   void getUserProfile_e2e_200() {
     ProfileResultDto actual = new ProfileResultDto(LoginE2ETests.user);
@@ -151,6 +159,7 @@ public class LoginE2ETests {
   }
 
   @Test
+  @Order(2)
   @DisplayName("GET /profile 401")
   void getUserProfile_e2e_401() {
     given()

--- a/src/test/java/com/fanfixiv/auth/RegisterE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/RegisterE2ETests.java
@@ -1,0 +1,159 @@
+package com.fanfixiv.auth;
+
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doAnswer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import com.fanfixiv.auth.entity.ProfileEntity;
+import com.fanfixiv.auth.repository.ProfileRepository;
+import com.fanfixiv.auth.service.MailService;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class RegisterE2ETests {
+
+  @Autowired
+  ProfileRepository profileRepository;
+
+  @LocalServerPort
+  private int _port;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    port = _port;
+  }
+
+  @Test
+  @DisplayName("GET /register/dc-nick 200")
+  void isNickDouble_e2e_200() {
+    given()
+        .param("nickname", "test1")
+        .get("/register/dc-nick")
+        .then()
+        .statusCode(200)
+        .assertThat()
+        .body("can_use", equalTo(true));
+
+    profileRepository.save(
+        ProfileEntity.builder()
+            .nickname("test1")
+            .build());
+
+    given()
+        .param("nickname", "test1")
+        .get("/register/dc-nick")
+        .then()
+        .statusCode(200)
+        .assertThat()
+        .body("can_use", equalTo(false));
+
+  }
+
+  @Test
+  @DisplayName("GET /register/dc-nick 400")
+  void isNickDouble_e2e_400() {
+    given()
+        .get("/register/dc-nick")
+        .then()
+        .statusCode(400);
+  }
+
+  // ===
+
+  @MockBean
+  MailService mailService;
+
+  static String uuid = "";
+  static String num = "";
+
+  @Test
+  @DisplayName("GET /register/cert-email 200")
+  void certEmail_e2e_200() {
+    
+    doAnswer(
+      new Answer<Object>() {
+      public Object answer(InvocationOnMock invocation) {
+          RegisterE2ETests.num = (String)invocation.getArgument(1);
+          return null;
+      }})
+    .when(mailService)
+    .sendMail(anyString(), anyString(), anyList());
+    
+    RegisterE2ETests.uuid = given()
+        .param("email", "test@example.com")
+        .get("/register/cert-email")
+        .then()
+        .statusCode(200)
+        .extract()
+        .path("uuid");
+  }
+
+  @Test
+  @DisplayName("GET /register/cert-email 400")
+  void certEmail_e2e_400() {
+    given()
+        .get("/register/cert-email")
+        .then()
+        .statusCode(400);
+  }
+
+  // ===
+
+  @Test
+  @DisplayName("GET /register/cert-number 200")
+  void certNumber_e2e_200() {
+
+    given()
+        .param("uuid",
+            RegisterE2ETests.uuid)
+        .param("number",
+            RegisterE2ETests.num)
+        .get("/register/cert-number")
+        .then()
+        .statusCode(200)
+        .assertThat()
+        .body("success", equalTo(true));
+
+    given()
+        .param("uuid",
+            "testuuid-1234")
+        .param("number",
+            "1234")
+        .get("/register/cert-number")
+        .then()
+        .statusCode(200)
+        .assertThat()
+        .body("success", equalTo(false));
+  }
+
+  @Test
+  @DisplayName("GET /register/cert-number 400")
+  void certNumber_e2e_400() {
+    given()
+        .get("/register/cert-email")
+        .then()
+        .statusCode(400);
+    given()
+        .param("number",
+            "1234")
+        .get("/register/cert-email")
+        .then()
+        .statusCode(400);
+    given()
+        .param("uuid",
+            "testuuid-1234")
+        .get("/register/cert-email")
+        .then()
+        .statusCode(400);
+  }
+}


### PR DESCRIPTION
> #24 참고

**PR 설명**
프로필 아이콘을 업로드하는 API와 회원가입 API를 연동하였습니다. 프로필 이미지가 존재할 경우 `POST /register`에서  `POST /profile-img/form`에 요청합니다.

**개발된 기능**
- 변수명 Camel Case로 변경
- redisTemplate Bean 추가
- RestRequester 추가
- `POST /register`에서  `POST /profile-img/form` 요청
-  `POST /register` 테스트 추가

**레퍼런스**
- https://blog.naver.com/hj_kim97/222295259904
