### PR TITLE
[비밀번호 찾기 페이지] 비밀번호 초기화 API 생성

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -44,6 +44,7 @@ jobs:
           TWITTER_CLIENT_ID: ${{ secrets.TWITTER_CLIENT_ID }}
           TWITTER_CLIENT_SECRET: ${{ secrets.TWITTER_CLIENT_SECRET }}
           FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
+          FRONTEND_ORIGIN: ${{ secrets.FRONTEND_ORIGIN }}
           MAIN_SERVER_URL: ${{ secrets.MAIN_SERVER_URL }}
           S3_URL: ${{ secrets.S3_URL }}
           REDIS_HOST: 127.0.0.1

--- a/src/main/java/com/fanfixiv/auth/config/SecurityConfig.java
+++ b/src/main/java/com/fanfixiv/auth/config/SecurityConfig.java
@@ -121,7 +121,7 @@ public class SecurityConfig {
     http.authorizeRequests()
         .antMatchers(HttpMethod.OPTIONS, "/**")
         .permitAll()
-        .antMatchers("/", "/login", "/logout", "/register/**", "/reset/**", "/refresh")
+        .antMatchers("/", "/login", "/logout", "/refresh", "/register/**", "/reset/**")
         .permitAll(); // 로그인 회원가입은 보안 해제
 
     http.authorizeRequests()

--- a/src/main/java/com/fanfixiv/auth/config/SecurityConfig.java
+++ b/src/main/java/com/fanfixiv/auth/config/SecurityConfig.java
@@ -121,7 +121,7 @@ public class SecurityConfig {
     http.authorizeRequests()
         .antMatchers(HttpMethod.OPTIONS, "/**")
         .permitAll()
-        .antMatchers("/", "/login", "/logout", "/register/**", "/refresh")
+        .antMatchers("/", "/login", "/logout", "/register/**", "/reset/**", "/refresh")
         .permitAll(); // 로그인 회원가입은 보안 해제
 
     http.authorizeRequests()

--- a/src/main/java/com/fanfixiv/auth/controller/ResetController.java
+++ b/src/main/java/com/fanfixiv/auth/controller/ResetController.java
@@ -1,0 +1,34 @@
+package com.fanfixiv.auth.controller;
+
+import com.fanfixiv.auth.dto.BaseResultDto;
+import com.fanfixiv.auth.dto.register.CertEmailDto;
+import com.fanfixiv.auth.dto.reset.ResetTokenDto;
+import com.fanfixiv.auth.service.ResetService;
+
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+@RequiredArgsConstructor
+@RequestMapping("/reset")
+public class ResetController {
+
+  private final ResetService resetService;
+
+  @PostMapping("/email")
+  public BaseResultDto resetEmail(@RequestBody @Valid CertEmailDto dto) {
+    return resetService.resetEmail(dto);
+  }
+
+  @PostMapping("/pw")
+  public BaseResultDto resetPw(@RequestBody @Valid ResetTokenDto dto) {
+    return resetService.resetPw(dto);
+  }
+
+}

--- a/src/main/java/com/fanfixiv/auth/controller/advice/GlobalControllerAdvice.java
+++ b/src/main/java/com/fanfixiv/auth/controller/advice/GlobalControllerAdvice.java
@@ -7,6 +7,7 @@ import com.fanfixiv.auth.exception.DuplicateException;
 import com.fanfixiv.auth.exception.EmailNotExisitException;
 import com.fanfixiv.auth.exception.ErrorResponse;
 import com.fanfixiv.auth.exception.MicroRequestException;
+import com.fanfixiv.auth.exception.TokenNotValidException;
 
 import java.util.List;
 import org.springframework.http.HttpStatus;
@@ -32,7 +33,8 @@ public class GlobalControllerAdvice {
   @ExceptionHandler({
       MissingServletRequestParameterException.class,
       DuplicateException.class,
-      EmailNotExisitException.class
+      EmailNotExisitException.class,
+      TokenNotValidException.class
   })
   public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(Exception e) {
     ErrorResponse err = new ErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage());

--- a/src/main/java/com/fanfixiv/auth/controller/advice/GlobalControllerAdvice.java
+++ b/src/main/java/com/fanfixiv/auth/controller/advice/GlobalControllerAdvice.java
@@ -18,11 +18,18 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.InitBinder;
 
 @ControllerAdvice(basePackageClasses = { LoginController.class, RegisterController.class, ResetController.class })
 public class GlobalControllerAdvice {
+
+  @InitBinder
+  public void initBinder(WebDataBinder binder) {
+    binder.initDirectFieldAccess();
+  }
 
   @ExceptionHandler({ UsernameNotFoundException.class, BadCredentialsException.class })
   public ResponseEntity<ErrorResponse> handleLoginException(Exception e) {

--- a/src/main/java/com/fanfixiv/auth/controller/advice/GlobalControllerAdvice.java
+++ b/src/main/java/com/fanfixiv/auth/controller/advice/GlobalControllerAdvice.java
@@ -2,7 +2,9 @@ package com.fanfixiv.auth.controller.advice;
 
 import com.fanfixiv.auth.controller.LoginController;
 import com.fanfixiv.auth.controller.RegisterController;
+import com.fanfixiv.auth.controller.ResetController;
 import com.fanfixiv.auth.exception.DuplicateException;
+import com.fanfixiv.auth.exception.EmailNotExisitException;
 import com.fanfixiv.auth.exception.ErrorResponse;
 import com.fanfixiv.auth.exception.MicroRequestException;
 
@@ -18,8 +20,9 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
-@ControllerAdvice(basePackageClasses = { LoginController.class, RegisterController.class })
+@ControllerAdvice(basePackageClasses = { LoginController.class, RegisterController.class, ResetController.class })
 public class GlobalControllerAdvice {
+
   @ExceptionHandler({ UsernameNotFoundException.class, BadCredentialsException.class })
   public ResponseEntity<ErrorResponse> handleLoginException(Exception e) {
     ErrorResponse err = new ErrorResponse(HttpStatus.UNAUTHORIZED, e.getMessage());
@@ -28,7 +31,8 @@ public class GlobalControllerAdvice {
 
   @ExceptionHandler({
       MissingServletRequestParameterException.class,
-      DuplicateException.class
+      DuplicateException.class,
+      EmailNotExisitException.class
   })
   public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(Exception e) {
     ErrorResponse err = new ErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage());

--- a/src/main/java/com/fanfixiv/auth/dto/BaseResultDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/BaseResultDto.java
@@ -1,0 +1,12 @@
+package com.fanfixiv.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class BaseResultDto {
+  private int status;
+
+  public BaseResultDto() {
+    this.status = 200;
+  }
+}

--- a/src/main/java/com/fanfixiv/auth/dto/login/LoginDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/login/LoginDto.java
@@ -2,10 +2,10 @@ package com.fanfixiv.auth.dto.login;
 
 import javax.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class LoginDto {

--- a/src/main/java/com/fanfixiv/auth/dto/login/LoginResultDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/login/LoginResultDto.java
@@ -1,9 +1,9 @@
 package com.fanfixiv.auth.dto.login;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 @AllArgsConstructor
 public class LoginResultDto {
   private String token;

--- a/src/main/java/com/fanfixiv/auth/dto/login/LogoutResultDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/login/LogoutResultDto.java
@@ -1,10 +1,10 @@
 package com.fanfixiv.auth.dto.login;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class LogoutResultDto {

--- a/src/main/java/com/fanfixiv/auth/dto/profile/ProfileResultDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/profile/ProfileResultDto.java
@@ -6,9 +6,9 @@ import java.time.LocalDateTime;
 import com.fanfixiv.auth.entity.UserEntity;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 @AllArgsConstructor
 public class ProfileResultDto {
   private String email;

--- a/src/main/java/com/fanfixiv/auth/dto/redis/RedisResetDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/redis/RedisResetDto.java
@@ -1,0 +1,23 @@
+package com.fanfixiv.auth.dto.redis;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RedisHash(value = "reset", timeToLive = 10 * 60)
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RedisResetDto {
+  @Id
+  private String uuid;
+
+  private String email;
+}

--- a/src/main/java/com/fanfixiv/auth/dto/register/CertEmailDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/register/CertEmailDto.java
@@ -4,10 +4,10 @@ import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class CertEmailDto {

--- a/src/main/java/com/fanfixiv/auth/dto/register/CertEmailResultDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/register/CertEmailResultDto.java
@@ -2,10 +2,10 @@ package com.fanfixiv.auth.dto.register;
 
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class CertEmailResultDto {

--- a/src/main/java/com/fanfixiv/auth/dto/register/CertNumberDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/register/CertNumberDto.java
@@ -3,10 +3,10 @@ package com.fanfixiv.auth.dto.register;
 import javax.validation.constraints.NotEmpty;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class CertNumberDto {

--- a/src/main/java/com/fanfixiv/auth/dto/register/CertNumberResultDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/register/CertNumberResultDto.java
@@ -1,10 +1,10 @@
 package com.fanfixiv.auth.dto.register;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class CertNumberResultDto {

--- a/src/main/java/com/fanfixiv/auth/dto/register/DoubleCheckDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/register/DoubleCheckDto.java
@@ -1,9 +1,9 @@
 package com.fanfixiv.auth.dto.register;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 @AllArgsConstructor
 public class DoubleCheckDto {
   private boolean canUse;

--- a/src/main/java/com/fanfixiv/auth/dto/register/RegisterDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/register/RegisterDto.java
@@ -3,10 +3,10 @@ package com.fanfixiv.auth.dto.register;
 import javax.validation.constraints.NotEmpty;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class RegisterDto {

--- a/src/main/java/com/fanfixiv/auth/dto/register/RegisterResultDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/register/RegisterResultDto.java
@@ -1,9 +1,9 @@
 package com.fanfixiv.auth.dto.register;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 @AllArgsConstructor
 public class RegisterResultDto {
   private String msg;

--- a/src/main/java/com/fanfixiv/auth/dto/reset/ResetTokenDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/reset/ResetTokenDto.java
@@ -1,0 +1,17 @@
+package com.fanfixiv.auth.dto.reset;
+
+import javax.validation.constraints.NotEmpty;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResetTokenDto {
+  @NotEmpty
+  private String token;
+  @NotEmpty
+  private String pw;
+}

--- a/src/main/java/com/fanfixiv/auth/dto/server/ProfileFormDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/server/ProfileFormDto.java
@@ -1,10 +1,10 @@
 package com.fanfixiv.auth.dto.server;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProfileFormDto {

--- a/src/main/java/com/fanfixiv/auth/entity/BaseEntity.java
+++ b/src/main/java/com/fanfixiv/auth/entity/BaseEntity.java
@@ -7,11 +7,14 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.Setter;
+
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
+@Setter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {

--- a/src/main/java/com/fanfixiv/auth/entity/ProfileEntity.java
+++ b/src/main/java/com/fanfixiv/auth/entity/ProfileEntity.java
@@ -9,11 +9,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
 @Getter
+@Setter
 @Builder
 @Entity
 @DynamicInsert

--- a/src/main/java/com/fanfixiv/auth/entity/RoleEntity.java
+++ b/src/main/java/com/fanfixiv/auth/entity/RoleEntity.java
@@ -8,6 +8,8 @@ import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
+
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
@@ -15,6 +17,7 @@ import org.hibernate.annotations.DynamicUpdate;
 import com.fanfixiv.auth.interfaces.UserRoleEnum;
 
 @Getter
+@Setter
 @Builder
 @Entity
 @DynamicInsert

--- a/src/main/java/com/fanfixiv/auth/entity/UserEntity.java
+++ b/src/main/java/com/fanfixiv/auth/entity/UserEntity.java
@@ -15,12 +15,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 @Getter
+@Setter
 @Builder
 @Entity
 @DynamicInsert

--- a/src/main/java/com/fanfixiv/auth/exception/EmailNotExisitException.java
+++ b/src/main/java/com/fanfixiv/auth/exception/EmailNotExisitException.java
@@ -1,0 +1,7 @@
+package com.fanfixiv.auth.exception;
+
+public class EmailNotExisitException extends RuntimeException {
+  public EmailNotExisitException(String msg) {
+    super(msg);
+  }
+}

--- a/src/main/java/com/fanfixiv/auth/exception/TokenNotValidException.java
+++ b/src/main/java/com/fanfixiv/auth/exception/TokenNotValidException.java
@@ -1,0 +1,7 @@
+package com.fanfixiv.auth.exception;
+
+public class TokenNotValidException extends RuntimeException {
+  public TokenNotValidException(String msg) {
+    super(msg);
+  }
+}

--- a/src/main/java/com/fanfixiv/auth/repository/RedisResetRepository.java
+++ b/src/main/java/com/fanfixiv/auth/repository/RedisResetRepository.java
@@ -1,0 +1,8 @@
+package com.fanfixiv.auth.repository;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.fanfixiv.auth.dto.redis.RedisResetDto;
+
+public interface RedisResetRepository extends CrudRepository<RedisResetDto, String> {
+}

--- a/src/main/java/com/fanfixiv/auth/service/LoginService.java
+++ b/src/main/java/com/fanfixiv/auth/service/LoginService.java
@@ -72,8 +72,7 @@ public class LoginService {
       return new LogoutResultDto(true);
     }
 
-    return new LogoutResultDto(false);
-
+    throw new BadCredentialsException("토큰값이 올바르지 않습니다.");
   }
 
   @Transactional

--- a/src/main/java/com/fanfixiv/auth/service/MailService.java
+++ b/src/main/java/com/fanfixiv/auth/service/MailService.java
@@ -2,6 +2,7 @@ package com.fanfixiv.auth.service;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring5.SpringTemplateEngine;
@@ -18,6 +19,9 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class MailService {
 
+  @Value("${micro.frontend.url}")
+  private String origin;
+
   private final AmazonSimpleEmailService amazonSimpleEmailService;
 
   private final SpringTemplateEngine templateEngine;
@@ -30,6 +34,17 @@ public class MailService {
     String html = templateEngine.process("auth", context);
 
     sendMail("FanFixiv 본인인증 이메일", html, receivers);
+  }
+
+  public void sendResetPwMail(final String resetUrl, final List<String> receivers) {
+    Context context = new Context();
+
+    // TODO: 후일 비밀번호 초기화 페이지 프론트엔드 개발되면 경로를 바꿀 것.
+    context.setVariable("resetUrl", origin + "reset/pw/" + resetUrl);
+
+    String html = templateEngine.process("reset", context);
+
+    sendMail("FanFixiv 비밀번호 초기화 이메일", html, receivers);
   }
 
   private void sendMail(final String subject, final String content, final List<String> receivers) {

--- a/src/main/java/com/fanfixiv/auth/service/RegisterService.java
+++ b/src/main/java/com/fanfixiv/auth/service/RegisterService.java
@@ -86,7 +86,7 @@ public class RegisterService {
         .email(redisDto.getEmail())
         .pw(dto.getPw())
         .profile(profile)
-        .role(Arrays.asList(RoleEntity.builder().role(UserRoleEnum.ROLE_USER).build()))
+        .role(Arrays.asList(new RoleEntity(UserRoleEnum.ROLE_USER)))
         .build();
 
     user.hashPassword(passwordEncoder);

--- a/src/main/java/com/fanfixiv/auth/service/ResetService.java
+++ b/src/main/java/com/fanfixiv/auth/service/ResetService.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 
 import javax.transaction.Transactional;
 
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +14,7 @@ import com.fanfixiv.auth.dto.register.CertEmailDto;
 import com.fanfixiv.auth.dto.reset.ResetTokenDto;
 import com.fanfixiv.auth.entity.UserEntity;
 import com.fanfixiv.auth.exception.EmailNotExisitException;
+import com.fanfixiv.auth.exception.TokenNotValidException;
 import com.fanfixiv.auth.repository.RedisResetRepository;
 import com.fanfixiv.auth.repository.UserRepository;
 import com.fanfixiv.auth.utils.RandomProvider;
@@ -59,7 +59,7 @@ public class ResetService {
 
     Optional<RedisResetDto> _rDto = redisResetRepository.findById(dto.getToken());
 
-    RedisResetDto rDto = _rDto.orElseThrow(() -> new BadCredentialsException("토큰값이 올바르지 않습니다."));
+    RedisResetDto rDto = _rDto.orElseThrow(() -> new TokenNotValidException("토큰값이 올바르지 않습니다."));
 
     redisResetRepository.deleteById(rDto.getUuid());
 

--- a/src/main/java/com/fanfixiv/auth/service/ResetService.java
+++ b/src/main/java/com/fanfixiv/auth/service/ResetService.java
@@ -1,0 +1,77 @@
+package com.fanfixiv.auth.service;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import javax.transaction.Transactional;
+
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.fanfixiv.auth.dto.BaseResultDto;
+import com.fanfixiv.auth.dto.redis.RedisResetDto;
+import com.fanfixiv.auth.dto.register.CertEmailDto;
+import com.fanfixiv.auth.dto.reset.ResetTokenDto;
+import com.fanfixiv.auth.entity.UserEntity;
+import com.fanfixiv.auth.exception.EmailNotExisitException;
+import com.fanfixiv.auth.repository.RedisResetRepository;
+import com.fanfixiv.auth.repository.UserRepository;
+import com.fanfixiv.auth.utils.RandomProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ResetService {
+
+  private final UserRepository userRepository;
+
+  private final RedisResetRepository redisResetRepository;
+
+  private final MailService mailService;
+
+  private final BCryptPasswordEncoder passwordEncoder;
+
+  public BaseResultDto resetEmail(CertEmailDto dto) {
+
+    if (userRepository.existsByEmail(dto.getEmail())) {
+      String uuid = RandomProvider.getUUID();
+
+      RedisResetDto rDto = RedisResetDto.builder()
+          .uuid(uuid)
+          .email(dto.getEmail())
+          .build();
+
+      redisResetRepository.save(rDto);
+
+      mailService.sendResetPwMail(uuid, Arrays.asList(dto.getEmail()));
+
+      return new BaseResultDto();
+    }
+
+    throw new EmailNotExisitException("이메일이 존재하지 않습니다.");
+
+  }
+
+  @Transactional
+  public BaseResultDto resetPw(ResetTokenDto dto) {
+
+    Optional<RedisResetDto> _rDto = redisResetRepository.findById(dto.getToken());
+
+    RedisResetDto rDto = _rDto.orElseThrow(() -> new BadCredentialsException("토큰값이 올바르지 않습니다."));
+
+    redisResetRepository.deleteById(rDto.getUuid());
+
+    UserEntity user = userRepository.findByEmail(rDto.getEmail());
+
+    user.setPw(dto.getPw());
+
+    user.hashPassword(passwordEncoder);
+
+    userRepository.save(user);
+
+    return new BaseResultDto();
+  }
+
+}

--- a/src/main/resources/mail-templates/reset.html
+++ b/src/main/resources/mail-templates/reset.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <a th:href="${resetUrl}">
+      <span
+        style="color: lightblue; font-size: xx-large"
+        th:text="${resetUrl}"
+      ></span>
+    </a>
+  </body>
+</html>

--- a/src/test/java/com/fanfixiv/auth/AuthE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/AuthE2ETests.java
@@ -4,23 +4,14 @@ import static io.restassured.RestAssured.*;
 // import static io.restassured.matcher.RestAssuredMatchers.*;
 import static org.hamcrest.Matchers.*;
 
-import com.fanfixiv.auth.entity.ProfileEntity;
-import com.fanfixiv.auth.repository.ProfileRepository;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class AuthE2ETests {
-
-  @Autowired
-  private ProfileRepository profileRepository;
 
   @LocalServerPort
   private int _port;
@@ -39,20 +30,5 @@ public class AuthE2ETests {
         .assertThat()
         .body("content", equalTo("Hello World!!!"))
         .body("id", equalTo(0));
-  }
-
-  @Test
-  @DisplayName("H2 데이터 베이스 테스트")
-  void h2test() {
-
-    profileRepository.deleteAll();
-
-    ProfileEntity _p = ProfileEntity.builder().nickname("테스트").descript("테스트입니다.").build();
-
-    profileRepository.save(_p);
-
-    ProfileEntity p = profileRepository.findAll().get(0);
-
-    assertEquals(_p.getNickname(), p.getNickname());
   }
 }

--- a/src/test/java/com/fanfixiv/auth/LoginE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/LoginE2ETests.java
@@ -84,10 +84,7 @@ public class LoginE2ETests {
 
     userRepository.save(user);
 
-    LoginDto lgdto = new LoginDto();
-
-    lgdto.setId(email);
-    lgdto.setPw(pw);
+    LoginDto lgdto = new LoginDto(email, pw);
 
     ExtractableResponse<Response> res = given()
         .contentType("application/json")
@@ -109,10 +106,7 @@ public class LoginE2ETests {
     String email = "test@example.com";
     String pw = "not_password";
 
-    LoginDto lgdto = new LoginDto();
-
-    lgdto.setId(email);
-    lgdto.setPw(pw);
+    LoginDto lgdto = new LoginDto(email, pw);
 
     given()
         .contentType("application/json")
@@ -129,9 +123,7 @@ public class LoginE2ETests {
 
     String email = "test@example.com";
 
-    LoginDto lgdto = new LoginDto();
-
-    lgdto.setId(email);
+    LoginDto lgdto = new LoginDto(email, null);
 
     given()
         .contentType("application/json")

--- a/src/test/java/com/fanfixiv/auth/ResetE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/ResetE2ETests.java
@@ -1,0 +1,167 @@
+package com.fanfixiv.auth;
+
+import static io.restassured.RestAssured.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doAnswer;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import com.fanfixiv.auth.dto.login.LoginDto;
+import com.fanfixiv.auth.dto.register.CertEmailDto;
+import com.fanfixiv.auth.dto.reset.ResetTokenDto;
+import com.fanfixiv.auth.entity.ProfileEntity;
+import com.fanfixiv.auth.entity.UserEntity;
+import com.fanfixiv.auth.repository.UserRepository;
+import com.fanfixiv.auth.service.MailService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class ResetE2ETests {
+
+  @Autowired
+  UserRepository userRepository;
+
+  @Autowired
+  BCryptPasswordEncoder passwordEncoder;
+
+  @LocalServerPort
+  private int _port;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    port = _port;
+  }
+
+  @MockBean
+  MailService mailService;
+
+  static String uuid = "";
+  static UserEntity user;
+
+  ObjectMapper objectMapper = new ObjectMapper();
+
+  private String objToJson(Object obj) {
+    try {
+      return this.objectMapper.writeValueAsString(obj);
+    } catch (Exception e) {
+      return "";
+    }
+  }
+
+  @Test
+  @Order(1)
+  @DisplayName("POST /reset/email 200")
+  void resetEmail_e2e_200() {
+    
+    String email = "test@example.com";
+    String pw = "password";
+    String nick = "테스트계정";
+
+    ProfileEntity profile = ProfileEntity.builder()
+        .nickname(nick)
+        .birth(LocalDate.of(2002, 8, 19))
+        .build();
+
+    ResetE2ETests.user = UserEntity.builder()
+        .email(email)
+        .pw(pw)
+        .profile(profile)
+        .build();
+
+    user.hashPassword(passwordEncoder);
+
+    userRepository.save(user);
+
+    doAnswer(
+      new Answer<Object>() {
+      public Object answer(InvocationOnMock invocation) {
+          ResetE2ETests.uuid = (String)invocation.getArgument(0);
+          return null;
+      }})
+    .when(mailService)
+    .sendResetPwMail(anyString(), anyList());
+    
+    CertEmailDto dto = new CertEmailDto(email);
+    
+    given()
+        .contentType("application/json")
+        .body(this.objToJson(dto))
+        .post("/reset/email")
+        .then()
+        .statusCode(200);
+  }
+
+  @Test
+  @Order(1)
+  @DisplayName("POST /reser/email 400")
+  void resetEmail_e2e_400() {
+    CertEmailDto dto = new CertEmailDto("noemail@example.com");
+    given()
+        .contentType("application/json")
+        .body(this.objToJson(dto))
+        .post("/reset/email")
+        .then()
+        .statusCode(400);
+  }
+
+  // ===
+
+  @Test
+  @Order(2)
+  @DisplayName("POST /reset/pw 200")
+  void resetPW_e2e_200() {
+
+    String email = "test@example.com";
+    String pw = "new_password";
+
+    ResetTokenDto dto = new ResetTokenDto(ResetE2ETests.uuid, pw);
+
+    given()
+        .contentType("application/json")
+        .body(this.objToJson(dto))
+        .post("/reset/pw")
+        .then()
+        .statusCode(200);
+
+    LoginDto lgdto = new LoginDto(email, pw);
+
+    given()
+        .contentType("application/json")
+        .body(this.objToJson(lgdto))
+        .post("/login")
+        .then()
+        .statusCode(200);
+  }
+
+  @Test
+  @Order(2)
+  @DisplayName("POST /reset/pw 400")
+  void resetPW_e2e_400() {
+
+    String pw = "new_password";
+
+    ResetTokenDto dto = new ResetTokenDto("TESTUUID", pw);
+
+    given()
+        .contentType("application/json")
+        .body(this.objToJson(dto))
+        .post("/reset/pw")
+        .then()
+        .statusCode(400);
+  }
+}


### PR DESCRIPTION
> #39 참고

**PR 설명**
비밀번호 초기화 API를 생성하였습니다.

**개발된 기능**
> 아직 이메일 템플릿이 없어서 임시 이메일 템플릿을 사용하였습니다.
- 비밀번호 초기화 토큰 로직
- 비밀번호 초기화 이메일 전송 API 추가 `POST /reset/email`
- 비밀번호 초기화 API 추가 `POST /reset/pw`
- 비밀번호 초기화 관련 테스트 추가

**레퍼런스**
없음
