### PR TITLE
[탈퇴] 계정 탈퇴 API 추가

### DIFF
--- a/src/main/java/com/fanfixiv/auth/controller/LoginController.java
+++ b/src/main/java/com/fanfixiv/auth/controller/LoginController.java
@@ -1,15 +1,19 @@
 package com.fanfixiv.auth.controller;
 
 import com.fanfixiv.auth.details.User;
+import com.fanfixiv.auth.dto.BaseResultDto;
 import com.fanfixiv.auth.dto.login.LoginDto;
 import com.fanfixiv.auth.dto.login.LoginResultDto;
 import com.fanfixiv.auth.dto.login.LogoutResultDto;
 import com.fanfixiv.auth.dto.profile.ProfileResultDto;
+import com.fanfixiv.auth.dto.secession.SecessionDto;
 import com.fanfixiv.auth.service.LoginService;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -50,5 +54,11 @@ public class LoginController {
   public ProfileResultDto profile(@AuthenticationPrincipal User user)
       throws Exception {
     return new ProfileResultDto(user.getUser());
+  }
+
+  @PostMapping("/secession")
+  public BaseResultDto secession(@AuthenticationPrincipal User user,
+      @RequestBody(required = false) @Nullable @Valid SecessionDto dto) {
+    return loginService.doSecession(user, dto);
   }
 }

--- a/src/main/java/com/fanfixiv/auth/controller/LoginController.java
+++ b/src/main/java/com/fanfixiv/auth/controller/LoginController.java
@@ -13,7 +13,6 @@ import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -58,7 +57,7 @@ public class LoginController {
 
   @PostMapping("/secession")
   public BaseResultDto secession(@AuthenticationPrincipal User user,
-      @RequestBody(required = false) @Nullable @Valid SecessionDto dto) {
+      @RequestBody(required = false) @Valid SecessionDto dto) {
     return loginService.doSecession(user, dto);
   }
 }

--- a/src/main/java/com/fanfixiv/auth/controller/advice/GlobalControllerAdvice.java
+++ b/src/main/java/com/fanfixiv/auth/controller/advice/GlobalControllerAdvice.java
@@ -7,6 +7,8 @@ import com.fanfixiv.auth.exception.DuplicateException;
 import com.fanfixiv.auth.exception.EmailNotExisitException;
 import com.fanfixiv.auth.exception.ErrorResponse;
 import com.fanfixiv.auth.exception.MicroRequestException;
+import com.fanfixiv.auth.exception.PasswordNotCorrectException;
+import com.fanfixiv.auth.exception.SecessionAccountExcetpion;
 import com.fanfixiv.auth.exception.TokenNotValidException;
 
 import java.util.List;
@@ -41,7 +43,9 @@ public class GlobalControllerAdvice {
       MissingServletRequestParameterException.class,
       DuplicateException.class,
       EmailNotExisitException.class,
-      TokenNotValidException.class
+      TokenNotValidException.class,
+      SecessionAccountExcetpion.class,
+      PasswordNotCorrectException.class
   })
   public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(Exception e) {
     ErrorResponse err = new ErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage());

--- a/src/main/java/com/fanfixiv/auth/controller/advice/GlobalControllerAdvice.java
+++ b/src/main/java/com/fanfixiv/auth/controller/advice/GlobalControllerAdvice.java
@@ -3,23 +3,18 @@ package com.fanfixiv.auth.controller.advice;
 import com.fanfixiv.auth.controller.LoginController;
 import com.fanfixiv.auth.controller.RegisterController;
 import com.fanfixiv.auth.controller.ResetController;
-import com.fanfixiv.auth.exception.DuplicateException;
-import com.fanfixiv.auth.exception.EmailNotExisitException;
+import com.fanfixiv.auth.exception.BadRequestException;
+import com.fanfixiv.auth.exception.BaseStatusException;
 import com.fanfixiv.auth.exception.ErrorResponse;
 import com.fanfixiv.auth.exception.MicroRequestException;
-import com.fanfixiv.auth.exception.PasswordNotCorrectException;
-import com.fanfixiv.auth.exception.SecessionAccountExcetpion;
-import com.fanfixiv.auth.exception.TokenNotValidException;
+import com.fanfixiv.auth.exception.UnauthorizedException;
 
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -33,30 +28,19 @@ public class GlobalControllerAdvice {
     binder.initDirectFieldAccess();
   }
 
-  @ExceptionHandler({ UsernameNotFoundException.class, BadCredentialsException.class })
-  public ResponseEntity<ErrorResponse> handleLoginException(Exception e) {
-    ErrorResponse err = new ErrorResponse(HttpStatus.UNAUTHORIZED, e.getMessage());
-    return new ResponseEntity<ErrorResponse>(err, HttpStatus.UNAUTHORIZED);
-  }
-
-  @ExceptionHandler({
-      MissingServletRequestParameterException.class,
-      DuplicateException.class,
-      EmailNotExisitException.class,
-      TokenNotValidException.class,
-      SecessionAccountExcetpion.class,
-      PasswordNotCorrectException.class
-  })
-  public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(Exception e) {
-    ErrorResponse err = new ErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage());
-    return new ResponseEntity<ErrorResponse>(err, HttpStatus.BAD_REQUEST);
+  @ExceptionHandler({ UnauthorizedException.class, BadRequestException.class })
+  public ResponseEntity<ErrorResponse> handleLoginException(BaseStatusException e) {
+    ErrorResponse err = new ErrorResponse(e.getStatus(), e.getMessage());
+    return new ResponseEntity<ErrorResponse>(err, e.getStatus());
   }
 
   @ExceptionHandler({
       MicroRequestException.class
   })
   public ResponseEntity<ErrorResponse> handleMissingMicroRequestException(MicroRequestException e) {
-    ErrorResponse err = new ErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage(), e.getDefaultMessage());
+    ErrorResponse err = e.getData() == null
+        ? new ErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage(), e.getData())
+        : new ErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage(), e.getErr());
     return new ResponseEntity<ErrorResponse>(err, HttpStatus.BAD_REQUEST);
   }
 

--- a/src/main/java/com/fanfixiv/auth/dto/secession/SecessionDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/secession/SecessionDto.java
@@ -1,0 +1,15 @@
+package com.fanfixiv.auth.dto.secession;
+
+import javax.validation.constraints.NotEmpty;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SecessionDto {
+  @NotEmpty
+  private String pw;
+}

--- a/src/main/java/com/fanfixiv/auth/entity/SecessionEntity.java
+++ b/src/main/java/com/fanfixiv/auth/entity/SecessionEntity.java
@@ -1,0 +1,38 @@
+package com.fanfixiv.auth.entity;
+
+import java.time.LocalDate;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Getter
+@Setter
+@Entity
+@DynamicInsert
+@DynamicUpdate
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "tb_secession")
+public class SecessionEntity extends BaseEntity {
+
+  @Column
+  private String email;
+
+  @Column
+  private LocalDate secDate;
+
+  public SecessionEntity(String email) {
+    this.email = email;
+    this.secDate = LocalDate.now();
+  }
+
+}

--- a/src/main/java/com/fanfixiv/auth/entity/UserEntity.java
+++ b/src/main/java/com/fanfixiv/auth/entity/UserEntity.java
@@ -39,11 +39,13 @@ public class UserEntity extends BaseEntity {
   @Column
   private String pw;
 
-  @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.PERSIST)
+  @OneToMany(fetch = FetchType.EAGER, cascade = { CascadeType.PERSIST, CascadeType.REMOVE })
   @JoinColumn(name = "user_seq")
   private List<RoleEntity> role;
 
-  @OneToOne(cascade = CascadeType.PERSIST)
+  @OneToOne(cascade = {
+      CascadeType.PERSIST,
+      CascadeType.REMOVE })
   @JoinColumn(name = "profile_seq")
   private ProfileEntity profile;
 

--- a/src/main/java/com/fanfixiv/auth/exception/BadRequestException.java
+++ b/src/main/java/com/fanfixiv/auth/exception/BadRequestException.java
@@ -1,0 +1,9 @@
+package com.fanfixiv.auth.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class BadRequestException extends BaseStatusException {
+  public BadRequestException(String message) {
+    super(HttpStatus.BAD_REQUEST, message);
+  }
+}

--- a/src/main/java/com/fanfixiv/auth/exception/BaseStatusException.java
+++ b/src/main/java/com/fanfixiv/auth/exception/BaseStatusException.java
@@ -1,0 +1,16 @@
+package com.fanfixiv.auth.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class BaseStatusException extends RuntimeException {
+  protected HttpStatus status;
+
+  public BaseStatusException(HttpStatus status, String message) {
+    super(message);
+    this.status = status;
+  }
+
+}

--- a/src/main/java/com/fanfixiv/auth/exception/DuplicateException.java
+++ b/src/main/java/com/fanfixiv/auth/exception/DuplicateException.java
@@ -1,7 +1,0 @@
-package com.fanfixiv.auth.exception;
-
-public class DuplicateException extends RuntimeException {
-  public DuplicateException(String msg) {
-    super(msg);
-  }
-}

--- a/src/main/java/com/fanfixiv/auth/exception/EmailNotExisitException.java
+++ b/src/main/java/com/fanfixiv/auth/exception/EmailNotExisitException.java
@@ -1,7 +1,0 @@
-package com.fanfixiv.auth.exception;
-
-public class EmailNotExisitException extends RuntimeException {
-  public EmailNotExisitException(String msg) {
-    super(msg);
-  }
-}

--- a/src/main/java/com/fanfixiv/auth/exception/ErrorResponse.java
+++ b/src/main/java/com/fanfixiv/auth/exception/ErrorResponse.java
@@ -5,12 +5,17 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+import com.fanfixiv.auth.dto.server.BaseResultFormDto;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 @Getter
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ErrorResponse {
   private int status;
   private String message;
   private List<String> err;
+  private BaseResultFormDto data;
 
   public ErrorResponse(HttpStatus status, String message) {
     this.status = status.value();
@@ -21,5 +26,11 @@ public class ErrorResponse {
     this.status = status.value();
     this.message = message;
     this.err = err;
+  }
+
+  public ErrorResponse(HttpStatus status, String message, BaseResultFormDto data) {
+    this.status = status.value();
+    this.message = message;
+    this.data = data;
   }
 }

--- a/src/main/java/com/fanfixiv/auth/exception/MicroRequestException.java
+++ b/src/main/java/com/fanfixiv/auth/exception/MicroRequestException.java
@@ -2,15 +2,23 @@ package com.fanfixiv.auth.exception;
 
 import java.util.List;
 
+import com.fanfixiv.auth.dto.server.BaseResultFormDto;
+
 import lombok.Getter;
 
 @Getter
 public class MicroRequestException extends RuntimeException {
 
-  private List<String> defaultMessage;
+  private BaseResultFormDto data;
+  private List<String> err;
 
-  public MicroRequestException(String msg, List<String> defaultMessage) {
+  public MicroRequestException(String msg, BaseResultFormDto data) {
     super(msg);
-    this.defaultMessage = defaultMessage;
+    this.data = data;
+  }
+
+  public MicroRequestException(String msg, List<String> err) {
+    super(msg);
+    this.err = err;
   }
 }

--- a/src/main/java/com/fanfixiv/auth/exception/PasswordNotCorrectException.java
+++ b/src/main/java/com/fanfixiv/auth/exception/PasswordNotCorrectException.java
@@ -1,7 +1,0 @@
-package com.fanfixiv.auth.exception;
-
-public class PasswordNotCorrectException extends RuntimeException {
-  public PasswordNotCorrectException(String msg) {
-    super(msg);
-  }
-}

--- a/src/main/java/com/fanfixiv/auth/exception/PasswordNotCorrectException.java
+++ b/src/main/java/com/fanfixiv/auth/exception/PasswordNotCorrectException.java
@@ -1,0 +1,7 @@
+package com.fanfixiv.auth.exception;
+
+public class PasswordNotCorrectException extends RuntimeException {
+  public PasswordNotCorrectException(String msg) {
+    super(msg);
+  }
+}

--- a/src/main/java/com/fanfixiv/auth/exception/SecessionAccountExcetpion.java
+++ b/src/main/java/com/fanfixiv/auth/exception/SecessionAccountExcetpion.java
@@ -1,0 +1,7 @@
+package com.fanfixiv.auth.exception;
+
+public class SecessionAccountExcetpion extends RuntimeException {
+  public SecessionAccountExcetpion(String msg) {
+    super(msg);
+  }
+}

--- a/src/main/java/com/fanfixiv/auth/exception/SecessionAccountExcetpion.java
+++ b/src/main/java/com/fanfixiv/auth/exception/SecessionAccountExcetpion.java
@@ -1,7 +1,0 @@
-package com.fanfixiv.auth.exception;
-
-public class SecessionAccountExcetpion extends RuntimeException {
-  public SecessionAccountExcetpion(String msg) {
-    super(msg);
-  }
-}

--- a/src/main/java/com/fanfixiv/auth/exception/TokenNotValidException.java
+++ b/src/main/java/com/fanfixiv/auth/exception/TokenNotValidException.java
@@ -1,7 +1,0 @@
-package com.fanfixiv.auth.exception;
-
-public class TokenNotValidException extends RuntimeException {
-  public TokenNotValidException(String msg) {
-    super(msg);
-  }
-}

--- a/src/main/java/com/fanfixiv/auth/exception/UnauthorizedException.java
+++ b/src/main/java/com/fanfixiv/auth/exception/UnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.fanfixiv.auth.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedException extends BaseStatusException {
+  public UnauthorizedException(String message) {
+    super(HttpStatus.UNAUTHORIZED, message);
+  }
+}

--- a/src/main/java/com/fanfixiv/auth/repository/SecessionRepository.java
+++ b/src/main/java/com/fanfixiv/auth/repository/SecessionRepository.java
@@ -1,0 +1,10 @@
+package com.fanfixiv.auth.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.fanfixiv.auth.entity.SecessionEntity;
+
+public interface SecessionRepository extends JpaRepository<SecessionEntity, Long> {
+  boolean existsByEmail(String email);
+  SecessionEntity findByEmail(String email);
+}

--- a/src/main/java/com/fanfixiv/auth/requester/RestRequester.java
+++ b/src/main/java/com/fanfixiv/auth/requester/RestRequester.java
@@ -46,7 +46,7 @@ public class RestRequester {
     if (result == null || result.getStatus() == 400)
       throw new MicroRequestException(
           "메인서버의 응답이 올바르지 않습니다.",
-          result == null ? null : Arrays.asList(result.getMessage()));
+          result);
 
     return result;
   }

--- a/src/main/java/com/fanfixiv/auth/service/CustomUserDetailService.java
+++ b/src/main/java/com/fanfixiv/auth/service/CustomUserDetailService.java
@@ -2,6 +2,7 @@ package com.fanfixiv.auth.service;
 
 import com.fanfixiv.auth.details.User;
 import com.fanfixiv.auth.entity.UserEntity;
+import com.fanfixiv.auth.exception.UnauthorizedException;
 import com.fanfixiv.auth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -9,7 +10,6 @@ import javax.transaction.Transactional;
 
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -20,11 +20,11 @@ public class CustomUserDetailService implements UserDetailsService {
 
   @Override
   @Transactional
-  public UserDetails loadUserByUsername(String _id) throws UsernameNotFoundException {
+  public UserDetails loadUserByUsername(String _id) throws UnauthorizedException {
     Long id = Long.parseLong(_id);
     UserEntity user = userRepository
         .findById(id)
-        .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을수 없습니다."));
+        .orElseThrow(() -> new UnauthorizedException("사용자를 찾을수 없습니다."));
 
     return new User(user);
   }

--- a/src/main/java/com/fanfixiv/auth/service/LoginService.java
+++ b/src/main/java/com/fanfixiv/auth/service/LoginService.java
@@ -9,7 +9,8 @@ import com.fanfixiv.auth.dto.redis.RedisAuthDto;
 import com.fanfixiv.auth.dto.secession.SecessionDto;
 import com.fanfixiv.auth.entity.SecessionEntity;
 import com.fanfixiv.auth.entity.UserEntity;
-import com.fanfixiv.auth.exception.PasswordNotCorrectException;
+import com.fanfixiv.auth.exception.BadRequestException;
+import com.fanfixiv.auth.exception.UnauthorizedException;
 import com.fanfixiv.auth.interfaces.UserRoleEnum;
 import com.fanfixiv.auth.repository.RedisAuthRepository;
 import com.fanfixiv.auth.repository.SecessionRepository;
@@ -25,8 +26,6 @@ import javax.transaction.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -48,13 +47,13 @@ public class LoginService {
   public LoginResultDto doLogin(HttpServletResponse response, LoginDto loginDto) throws Exception {
 
     if (!userRepository.existsByEmail(loginDto.getId())) {
-      throw new UsernameNotFoundException("사용자를 찾을수 없습니다.");
+      throw new UnauthorizedException("사용자를 찾을수 없습니다.");
     }
 
     UserEntity user = userRepository.findByEmail(loginDto.getId());
 
     if (!user.checkPassword(loginDto.getPw(), passwordEncoder)) {
-      throw new BadCredentialsException("비밀번호가 불일치 합니다.");
+      throw new UnauthorizedException("비밀번호가 불일치 합니다.");
     }
 
     List<UserRoleEnum> roles = user.getRole().stream().map(item -> item.getRole()).toList();
@@ -71,7 +70,7 @@ public class LoginService {
   public LogoutResultDto doLogout(String refresh, String token) throws Exception {
 
     Optional<RedisAuthDto> _authDto = redisAuthRepository.findById(refresh);
-    RedisAuthDto authDto = _authDto.orElseThrow(() -> new BadCredentialsException("토큰값이 올바르지 않습니다."));
+    RedisAuthDto authDto = _authDto.orElseThrow(() -> new UnauthorizedException("토큰값이 올바르지 않습니다."));
 
     token = jwtTokenProvider.bearerRemove(token);
 
@@ -80,7 +79,7 @@ public class LoginService {
       return new LogoutResultDto(true);
     }
 
-    throw new BadCredentialsException("토큰값이 올바르지 않습니다.");
+    throw new UnauthorizedException("토큰값이 올바르지 않습니다.");
   }
 
   @Transactional
@@ -88,7 +87,7 @@ public class LoginService {
     Optional<RedisAuthDto> _authDto = redisAuthRepository.findById(refresh);
     token = jwtTokenProvider.bearerRemove(token);
 
-    RedisAuthDto authDto = _authDto.orElseThrow(() -> new BadCredentialsException("토큰값이 올바르지 않습니다."));
+    RedisAuthDto authDto = _authDto.orElseThrow(() -> new UnauthorizedException("토큰값이 올바르지 않습니다."));
 
     if (authDto.getJwtToken().equals(token)) {
       token = jwtTokenProvider.createTokenWithInVailedToken(token);
@@ -96,7 +95,7 @@ public class LoginService {
       return new LoginResultDto(token);
     }
 
-    throw new BadCredentialsException("토큰값이 올바르지 않습니다.");
+    throw new UnauthorizedException("토큰값이 올바르지 않습니다.");
   }
 
   @Transactional
@@ -107,11 +106,11 @@ public class LoginService {
     UserEntity userEntity = userRepository.findById(seq).get();
 
     if (dto == null && userEntity.getPw() != null) {
-      throw new PasswordNotCorrectException("비밀번호를 입력해주세요.");
+      throw new BadRequestException("비밀번호를 입력해주세요.");
     }
 
     if (dto != null && !userEntity.checkPassword(dto.getPw(), passwordEncoder)) {
-      throw new PasswordNotCorrectException("비밀번호가 일치하지 않습니다.");
+      throw new BadRequestException("비밀번호가 일치하지 않습니다.");
     }
 
     userRepository.delete(userEntity);

--- a/src/main/java/com/fanfixiv/auth/service/RegisterService.java
+++ b/src/main/java/com/fanfixiv/auth/service/RegisterService.java
@@ -10,8 +10,7 @@ import com.fanfixiv.auth.dto.register.RegisterResultDto;
 import com.fanfixiv.auth.entity.ProfileEntity;
 import com.fanfixiv.auth.entity.RoleEntity;
 import com.fanfixiv.auth.entity.UserEntity;
-import com.fanfixiv.auth.exception.DuplicateException;
-import com.fanfixiv.auth.exception.SecessionAccountExcetpion;
+import com.fanfixiv.auth.exception.BadRequestException;
 import com.fanfixiv.auth.repository.ProfileRepository;
 import com.fanfixiv.auth.repository.RedisEmailRepository;
 import com.fanfixiv.auth.repository.SecessionRepository;
@@ -58,21 +57,21 @@ public class RegisterService {
   @Transactional
   public RegisterResultDto register(RegisterDto dto) {
     if (profileRepository.existsByNickname(dto.getNickname())) {
-      throw new DuplicateException("이미 사용중인 닉네임입니다.");
+      throw new BadRequestException("이미 사용중인 닉네임입니다.");
     }
 
     Optional<RedisEmailAuthDto> _redisDto = redisEmailRepository.findById(dto.getUuid());
-    RedisEmailAuthDto redisDto = _redisDto.orElseThrow(() -> new DuplicateException("본인인증이 되어있지 않습니다."));
+    RedisEmailAuthDto redisDto = _redisDto.orElseThrow(() -> new BadRequestException("본인인증이 되어있지 않습니다."));
 
     if (userRepository.existsByEmail(redisDto.getEmail())) {
-      throw new DuplicateException("이미 사용중인 이메일입니다.");
+      throw new BadRequestException("이미 사용중인 이메일입니다.");
     }
     if (!redisDto.isSuccess()) {
-      throw new DuplicateException("본인인증이 되어있지 않습니다.");
+      throw new BadRequestException("본인인증이 되어있지 않습니다.");
     }
     if (secessionRepository.existsByEmail(redisDto.getEmail()) &&
         secessionRepository.findByEmail(redisDto.getEmail()).getSecDate().plusDays(30).isAfter(LocalDate.now())) {
-      throw new SecessionAccountExcetpion("탈퇴한 계정은 30일간 재가입 할수 없습니다.");
+      throw new BadRequestException("탈퇴한 계정은 30일간 재가입 할수 없습니다.");
     }
 
     String profileImgUrl = "";
@@ -111,7 +110,7 @@ public class RegisterService {
   @Transactional
   public CertEmailResultDto certEmail(String email) {
     if (userRepository.existsByEmail(email)) {
-      throw new DuplicateException("이미 사용중인 이메일입니다.");
+      throw new BadRequestException("이미 사용중인 이메일입니다.");
     }
 
     String uuid = RandomProvider.getUUID();

--- a/src/main/java/com/fanfixiv/auth/service/ResetService.java
+++ b/src/main/java/com/fanfixiv/auth/service/ResetService.java
@@ -13,8 +13,7 @@ import com.fanfixiv.auth.dto.redis.RedisResetDto;
 import com.fanfixiv.auth.dto.register.CertEmailDto;
 import com.fanfixiv.auth.dto.reset.ResetTokenDto;
 import com.fanfixiv.auth.entity.UserEntity;
-import com.fanfixiv.auth.exception.EmailNotExisitException;
-import com.fanfixiv.auth.exception.TokenNotValidException;
+import com.fanfixiv.auth.exception.BadRequestException;
 import com.fanfixiv.auth.repository.RedisResetRepository;
 import com.fanfixiv.auth.repository.UserRepository;
 import com.fanfixiv.auth.utils.RandomProvider;
@@ -50,7 +49,7 @@ public class ResetService {
       return new BaseResultDto();
     }
 
-    throw new EmailNotExisitException("이메일이 존재하지 않습니다.");
+    throw new BadRequestException("이메일이 존재하지 않습니다.");
 
   }
 
@@ -59,7 +58,7 @@ public class ResetService {
 
     Optional<RedisResetDto> _rDto = redisResetRepository.findById(dto.getToken());
 
-    RedisResetDto rDto = _rDto.orElseThrow(() -> new TokenNotValidException("토큰값이 올바르지 않습니다."));
+    RedisResetDto rDto = _rDto.orElseThrow(() -> new BadRequestException("토큰값이 올바르지 않습니다."));
 
     redisResetRepository.deleteById(rDto.getUuid());
 

--- a/src/test/java/com/fanfixiv/auth/RegisterE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/RegisterE2ETests.java
@@ -17,8 +17,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
 
+import com.fanfixiv.auth.dto.login.LoginDto;
 import com.fanfixiv.auth.dto.register.RegisterDto;
+import com.fanfixiv.auth.dto.secession.SecessionDto;
 import com.fanfixiv.auth.entity.ProfileEntity;
 import com.fanfixiv.auth.repository.ProfileRepository;
 import com.fanfixiv.auth.service.MailService;
@@ -187,7 +190,7 @@ public class RegisterE2ETests {
   void register_e2e_200() {
 
     String pw = "password";
-    String nickname = "테스트계정";
+    String nickname = "회원가입 테스트계정";
     String birth = "2002-08-19";
 
     RegisterDto rgDto = new RegisterDto(
@@ -218,5 +221,43 @@ public class RegisterE2ETests {
         .post("/register")
         .then()
         .statusCode(400);
+  }
+
+  static String token = "";
+
+  @Test
+  @Order(6)
+  @DisplayName("POST /secession")
+  void secession_e2e() {
+
+    String email = "register@test.com";
+    String pw = "password";
+
+    LoginDto lgdto = new LoginDto(email, pw);
+
+    RegisterE2ETests.token = given()
+        .contentType("application/json")
+        .body(this.objToJson(lgdto))
+        .post("/login")
+        .then()
+        .statusCode(200)
+        .extract()
+        .path("token");
+
+    given()
+        .contentType("application/json")
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + RegisterE2ETests.token)
+        .body(new SecessionDto("wrong password"))
+        .post("/secession")
+        .then()
+        .statusCode(400);
+
+    given()
+        .contentType("application/json")
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + RegisterE2ETests.token)
+        .body(new SecessionDto(pw))
+        .post("/secession")
+        .then()
+        .statusCode(200);
   }
 }

--- a/src/test/java/com/fanfixiv/auth/ResetE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/ResetE2ETests.java
@@ -70,7 +70,7 @@ public class ResetE2ETests {
     
     String email = "test@example.com";
     String pw = "password";
-    String nick = "테스트계정";
+    String nick = "비밀번호 초기화 테스트계정";
 
     ProfileEntity profile = ProfileEntity.builder()
         .nickname(nick)
@@ -108,7 +108,7 @@ public class ResetE2ETests {
 
   @Test
   @Order(1)
-  @DisplayName("POST /reser/email 400")
+  @DisplayName("POST /reset/email 400")
   void resetEmail_e2e_400() {
     CertEmailDto dto = new CertEmailDto("noemail@example.com");
     given()


### PR DESCRIPTION
> #40 참고

**PR 설명**
탈퇴 API를 개발하였습니다. 탈퇴한 계정은 30일간 다시 가입하지 못하며 이는 소셜 로그인도 동일합니다. 소셜 로그인의 경우  `/twitter/login-false`로 리다이렉트 됩니다. 프론트엔드 분들은 이점 유의하며 개발 부탁드립니다.

**개발된 기능**
- `/POST /secession` API 추가
- 탈퇴 이후 가입 거부 로직 추가
- 소셜 로그인 가입 거부 리다이렉션 추가

**레퍼런스**
없음