### PR TITLE
[회원가입 페이지 구현] 프로필 아이콘 업로드 서비스 연동 (MQ 이용)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -48,15 +48,14 @@ jobs:
             test
             -i
         env:
+          SECRET: ${{ secrets.SECRET }}
           AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
-          SECRET: ${{ secrets.SECRET }}
           TWITTER_CLIENT_ID: ${{ secrets.TWITTER_CLIENT_ID }}
           TWITTER_CLIENT_SECRET: ${{ secrets.TWITTER_CLIENT_SECRET }}
-          FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
-          FRONTEND_ORIGIN: ${{ secrets.FRONTEND_ORIGIN }}
-          MAIN_SERVER_URL: ${{ secrets.MAIN_SERVER_URL }}
           S3_URL: ${{ secrets.S3_URL }}
+          FRONTEND_URL: https://giveusmoney.github.io/FanFixiv-user-page
+          FRONTEND_ORIGIN: https://giveusmoney.github.io/
           REDIS_HOST: 127.0.0.1
           MQ_HOST: localhost
           MQ_PORT: 5672

--- a/src/main/java/com/fanfixiv/auth/AuthApplication.java
+++ b/src/main/java/com/fanfixiv/auth/AuthApplication.java
@@ -4,10 +4,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
 @SpringBootApplication
 @EnableCaching
 @EnableJpaAuditing
+@EnableJpaRepositories(basePackages = "com.fanfixiv.auth.repository.jpa")
+@EnableRedisRepositories(basePackages = "com.fanfixiv.auth.repository.redis")
 public class AuthApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/fanfixiv/auth/config/RabbitMqConfig.java
+++ b/src/main/java/com/fanfixiv/auth/config/RabbitMqConfig.java
@@ -10,10 +10,13 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 @Configuration
 public class RabbitMqConfig {
 
+  private final String DEFAULT_EXCHANGE = "fanfixiv.main";
+
   @Bean
   RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
     RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
     rabbitTemplate.setMessageConverter(new Jackson2JsonMessageConverter());
+    rabbitTemplate.setExchange(DEFAULT_EXCHANGE);
     return rabbitTemplate;
   }
 

--- a/src/main/java/com/fanfixiv/auth/config/RedisConfig.java
+++ b/src/main/java/com/fanfixiv/auth/config/RedisConfig.java
@@ -5,9 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableRedisRepositories // Redis Repository 활성화
@@ -22,20 +20,5 @@ public class RedisConfig {
   @Bean
   public RedisConnectionFactory redisConnectionFactory() {
     return new LettuceConnectionFactory(host, port);
-  }
-
-  @Bean
-  public RedisTemplate<String, Object> redisTemplate() {
-    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-    redisTemplate.setConnectionFactory(redisConnectionFactory());
-    redisTemplate.setKeySerializer(new StringRedisSerializer());
-    redisTemplate.setValueSerializer(new StringRedisSerializer());
-    // Hash Operation 사용 시
-    redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-    redisTemplate.setHashValueSerializer(new StringRedisSerializer());
-
-    redisTemplate.setDefaultSerializer(new StringRedisSerializer());
-
-    return redisTemplate;
   }
 }

--- a/src/main/java/com/fanfixiv/auth/dto/server/ProfileFormDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/server/ProfileFormDto.java
@@ -9,5 +9,4 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ProfileFormDto {
   private String key;
-  private String auth;
 }

--- a/src/main/java/com/fanfixiv/auth/dto/server/ProfileFormResultDto.java
+++ b/src/main/java/com/fanfixiv/auth/dto/server/ProfileFormResultDto.java
@@ -2,8 +2,10 @@ package com.fanfixiv.auth.dto.server;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class ProfileFormResultDto extends BaseResultFormDto {
   private String key;

--- a/src/main/java/com/fanfixiv/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/fanfixiv/auth/handler/OAuth2SuccessHandler.java
@@ -19,8 +19,8 @@ import org.springframework.stereotype.Component;
 import com.fanfixiv.auth.dto.redis.RedisAuthDto;
 import com.fanfixiv.auth.entity.UserEntity;
 import com.fanfixiv.auth.interfaces.UserRoleEnum;
-import com.fanfixiv.auth.repository.RedisAuthRepository;
-import com.fanfixiv.auth.repository.UserRepository;
+import com.fanfixiv.auth.repository.jpa.UserRepository;
+import com.fanfixiv.auth.repository.redis.RedisAuthRepository;
 import com.fanfixiv.auth.utils.JwtTokenProvider;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/fanfixiv/auth/repository/jpa/ProfileRepository.java
+++ b/src/main/java/com/fanfixiv/auth/repository/jpa/ProfileRepository.java
@@ -1,8 +1,10 @@
-package com.fanfixiv.auth.repository;
+package com.fanfixiv.auth.repository.jpa;
 
 import com.fanfixiv.auth.entity.ProfileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ProfileRepository extends JpaRepository<ProfileEntity, Long> {
   boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/fanfixiv/auth/repository/jpa/UserRepository.java
+++ b/src/main/java/com/fanfixiv/auth/repository/jpa/UserRepository.java
@@ -1,4 +1,4 @@
-package com.fanfixiv.auth.repository;
+package com.fanfixiv.auth.repository.jpa;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/fanfixiv/auth/repository/redis/RedisAuthRepository.java
+++ b/src/main/java/com/fanfixiv/auth/repository/redis/RedisAuthRepository.java
@@ -1,4 +1,4 @@
-package com.fanfixiv.auth.repository;
+package com.fanfixiv.auth.repository.redis;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/fanfixiv/auth/repository/redis/RedisEmailRepository.java
+++ b/src/main/java/com/fanfixiv/auth/repository/redis/RedisEmailRepository.java
@@ -1,8 +1,10 @@
-package com.fanfixiv.auth.repository;
+package com.fanfixiv.auth.repository.redis;
 
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
 
 import com.fanfixiv.auth.dto.redis.RedisEmailAuthDto;
 
+@Repository
 public interface RedisEmailRepository extends CrudRepository<RedisEmailAuthDto, String> {
 }

--- a/src/main/java/com/fanfixiv/auth/repository/redis/RedisResetRepository.java
+++ b/src/main/java/com/fanfixiv/auth/repository/redis/RedisResetRepository.java
@@ -1,8 +1,10 @@
-package com.fanfixiv.auth.repository;
+package com.fanfixiv.auth.repository.redis;
 
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
 
 import com.fanfixiv.auth.dto.redis.RedisResetDto;
 
+@Repository
 public interface RedisResetRepository extends CrudRepository<RedisResetDto, String> {
 }

--- a/src/main/java/com/fanfixiv/auth/requester/MQRequester.java
+++ b/src/main/java/com/fanfixiv/auth/requester/MQRequester.java
@@ -1,0 +1,40 @@
+package com.fanfixiv.auth.requester;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Component;
+
+import com.fanfixiv.auth.dto.server.ProfileFormDto;
+import com.fanfixiv.auth.dto.server.ProfileFormResultDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MQRequester {
+
+  @Value("${aws.s3.url}")
+  private String s3Url;
+
+  private final RabbitTemplate rabbitTemplate;
+
+  public String profileImgForm(String key) {
+    ProfileFormResultDto result = rabbitTemplate.<ProfileFormResultDto>convertSendAndReceiveAsType(
+        "profile-img.form",
+        new ProfileFormDto(key),
+        new ParameterizedTypeReference<ProfileFormResultDto>() {
+        });
+
+    if (result == null) {
+      return null;
+    }
+
+    if (result.getStatus() != 200) {
+      return null;
+    }
+
+    return s3Url + result.getKey();
+  }
+
+}

--- a/src/main/java/com/fanfixiv/auth/requester/RestRequester.java
+++ b/src/main/java/com/fanfixiv/auth/requester/RestRequester.java
@@ -3,14 +3,11 @@ package com.fanfixiv.auth.requester;
 import java.util.Arrays;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import com.fanfixiv.auth.dto.server.BaseResultFormDto;
-import com.fanfixiv.auth.dto.server.ProfileFormDto;
-import com.fanfixiv.auth.dto.server.ProfileFormResultDto;
 import com.fanfixiv.auth.exception.MicroRequestException;
 
 import lombok.RequiredArgsConstructor;
@@ -19,15 +16,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RestRequester {
 
-  @Value("${micro.main-server.url}")
-  private String mainServerUrl;
-
   @Value("${aws.s3.url}")
   private String s3Url;
 
   private final RestTemplate restTemplate;
-
-  private final RedisTemplate<String, String> redisTemplate;
 
   private <T extends BaseResultFormDto, E> T postRequest(String uri, E dto, Class<T> clazz) {
     T result;
@@ -49,17 +41,6 @@ public class RestRequester {
           result == null ? null : Arrays.asList(result.getMessage()));
 
     return result;
-  }
-
-  public String uploadProfileImg(String key) {
-    String uri = mainServerUrl + "profile-img/form"; // or any other uri
-
-    ProfileFormResultDto result = this.postRequest(
-        uri,
-        new ProfileFormDto(key, redisTemplate.opsForValue().get("REDIS_AUTH")),
-        ProfileFormResultDto.class);
-
-    return s3Url + result.getKey();
   }
 
 }

--- a/src/main/java/com/fanfixiv/auth/service/CustomUserDetailService.java
+++ b/src/main/java/com/fanfixiv/auth/service/CustomUserDetailService.java
@@ -2,7 +2,8 @@ package com.fanfixiv.auth.service;
 
 import com.fanfixiv.auth.details.User;
 import com.fanfixiv.auth.entity.UserEntity;
-import com.fanfixiv.auth.repository.UserRepository;
+import com.fanfixiv.auth.repository.jpa.UserRepository;
+
 import lombok.RequiredArgsConstructor;
 
 import javax.transaction.Transactional;

--- a/src/main/java/com/fanfixiv/auth/service/LoginService.java
+++ b/src/main/java/com/fanfixiv/auth/service/LoginService.java
@@ -6,8 +6,8 @@ import com.fanfixiv.auth.dto.login.LogoutResultDto;
 import com.fanfixiv.auth.dto.redis.RedisAuthDto;
 import com.fanfixiv.auth.entity.UserEntity;
 import com.fanfixiv.auth.interfaces.UserRoleEnum;
-import com.fanfixiv.auth.repository.RedisAuthRepository;
-import com.fanfixiv.auth.repository.UserRepository;
+import com.fanfixiv.auth.repository.jpa.UserRepository;
+import com.fanfixiv.auth.repository.redis.RedisAuthRepository;
 import com.fanfixiv.auth.utils.JwtTokenProvider;
 import com.google.common.net.HttpHeaders;
 

--- a/src/main/java/com/fanfixiv/auth/service/RegisterService.java
+++ b/src/main/java/com/fanfixiv/auth/service/RegisterService.java
@@ -12,10 +12,10 @@ import com.fanfixiv.auth.entity.RoleEntity;
 import com.fanfixiv.auth.entity.UserEntity;
 import com.fanfixiv.auth.exception.DuplicateException;
 import com.fanfixiv.auth.interfaces.UserRoleEnum;
-import com.fanfixiv.auth.repository.ProfileRepository;
-import com.fanfixiv.auth.repository.RedisEmailRepository;
-import com.fanfixiv.auth.repository.UserRepository;
-import com.fanfixiv.auth.requester.RestRequester;
+import com.fanfixiv.auth.repository.jpa.ProfileRepository;
+import com.fanfixiv.auth.repository.jpa.UserRepository;
+import com.fanfixiv.auth.repository.redis.RedisEmailRepository;
+import com.fanfixiv.auth.requester.MQRequester;
 import com.fanfixiv.auth.utils.RandomProvider;
 import com.fanfixiv.auth.utils.TimeProvider;
 
@@ -48,7 +48,7 @@ public class RegisterService {
 
   private final BCryptPasswordEncoder passwordEncoder;
 
-  private final RestRequester restRequester;
+  private final MQRequester mqRequester;
 
   private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
@@ -70,7 +70,7 @@ public class RegisterService {
 
     String profileImgUrl = "";
     if (dto.getProfileImg() != null) {
-      profileImgUrl = restRequester.uploadProfileImg(dto.getProfileImg());
+      profileImgUrl = mqRequester.profileImgForm(dto.getProfileImg());
     }
 
     LocalDate birth = LocalDate.parse(dto.getBirth(), this.formatter);

--- a/src/main/java/com/fanfixiv/auth/service/ResetService.java
+++ b/src/main/java/com/fanfixiv/auth/service/ResetService.java
@@ -15,8 +15,8 @@ import com.fanfixiv.auth.dto.reset.ResetTokenDto;
 import com.fanfixiv.auth.entity.UserEntity;
 import com.fanfixiv.auth.exception.EmailNotExisitException;
 import com.fanfixiv.auth.exception.TokenNotValidException;
-import com.fanfixiv.auth.repository.RedisResetRepository;
-import com.fanfixiv.auth.repository.UserRepository;
+import com.fanfixiv.auth.repository.jpa.UserRepository;
+import com.fanfixiv.auth.repository.redis.RedisResetRepository;
 import com.fanfixiv.auth.utils.RandomProvider;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -36,11 +36,6 @@
       "description": "프론트엔드 URL"
     },
     {
-      "name": "micro.main-server.url",
-      "type": "java.lang.String",
-      "description": "메인 서버 URL"
-    },
-    {
       "name": "aws.s3.url",
       "type": "java.lang.String",
       "description": "s3 URL"

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -12,10 +12,6 @@ micro.frontend.origin=${FRONTEND_ORIGIN}
 micro.frontend.url=${FRONTEND_URL}
 aws.s3.url=${S3_URL}
 
-# microservice
-
-micro.main-server.url=${MAIN_SERVER_URL}
-
 # redis
 
 spring.redis.host=${REDIS_HOST}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -13,10 +13,6 @@ micro.frontend.origin=${FRONTEND_ORIGIN}
 micro.frontend.url=${FRONTEND_URL}
 aws.s3.url=${S3_URL}
 
-# microservice
-
-micro.main-server.url=${MAIN_SERVER_URL}
-
 # redis
 
 spring.redis.host=${REDIS_HOST}

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -11,9 +11,6 @@ micro.frontend.origin=${FRONTEND_ORIGIN}
 micro.frontend.url=${FRONTEND_URL}
 aws.s3.url=${S3_URL}
 
-# microservice
-
-micro.main-server.url=${MAIN_SERVER_URL}
 
 # redis
 spring.redis.host=${REDIS_HOST}

--- a/src/test/java/com/fanfixiv/auth/LoginE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/LoginE2ETests.java
@@ -21,7 +21,7 @@ import com.fanfixiv.auth.dto.login.LoginDto;
 import com.fanfixiv.auth.dto.profile.ProfileResultDto;
 import com.fanfixiv.auth.entity.ProfileEntity;
 import com.fanfixiv.auth.entity.UserEntity;
-import com.fanfixiv.auth.repository.UserRepository;
+import com.fanfixiv.auth.repository.jpa.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.restassured.response.ExtractableResponse;

--- a/src/test/java/com/fanfixiv/auth/RegisterE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/RegisterE2ETests.java
@@ -20,7 +20,7 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 
 import com.fanfixiv.auth.dto.register.RegisterDto;
 import com.fanfixiv.auth.entity.ProfileEntity;
-import com.fanfixiv.auth.repository.ProfileRepository;
+import com.fanfixiv.auth.repository.jpa.ProfileRepository;
 import com.fanfixiv.auth.service.MailService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -88,16 +88,17 @@ public class RegisterE2ETests {
   @Order(2)
   @DisplayName("GET /register/cert-email 200")
   void certEmail_e2e_200() {
-    
+
     doAnswer(
-      new Answer<Object>() {
-      public Object answer(InvocationOnMock invocation) {
-          RegisterE2ETests.num = (String)invocation.getArgument(0);
-          return null;
-      }})
-    .when(mailService)
-    .sendEmailAuthMail(anyString(), anyList());
-    
+        new Answer<Object>() {
+          public Object answer(InvocationOnMock invocation) {
+            RegisterE2ETests.num = (String) invocation.getArgument(0);
+            return null;
+          }
+        })
+        .when(mailService)
+        .sendEmailAuthMail(anyString(), anyList());
+
     RegisterE2ETests.uuid = given()
         .param("email", "register@test.com")
         .get("/register/cert-email")

--- a/src/test/java/com/fanfixiv/auth/ResetE2ETests.java
+++ b/src/test/java/com/fanfixiv/auth/ResetE2ETests.java
@@ -25,7 +25,7 @@ import com.fanfixiv.auth.dto.register.CertEmailDto;
 import com.fanfixiv.auth.dto.reset.ResetTokenDto;
 import com.fanfixiv.auth.entity.ProfileEntity;
 import com.fanfixiv.auth.entity.UserEntity;
-import com.fanfixiv.auth.repository.UserRepository;
+import com.fanfixiv.auth.repository.jpa.UserRepository;
 import com.fanfixiv.auth.service.MailService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -67,7 +67,7 @@ public class ResetE2ETests {
   @Order(1)
   @DisplayName("POST /reset/email 200")
   void resetEmail_e2e_200() {
-    
+
     String email = "test@example.com";
     String pw = "password";
     String nick = "테스트계정";
@@ -88,16 +88,17 @@ public class ResetE2ETests {
     userRepository.save(user);
 
     doAnswer(
-      new Answer<Object>() {
-      public Object answer(InvocationOnMock invocation) {
-          ResetE2ETests.uuid = (String)invocation.getArgument(0);
-          return null;
-      }})
-    .when(mailService)
-    .sendResetPwMail(anyString(), anyList());
-    
+        new Answer<Object>() {
+          public Object answer(InvocationOnMock invocation) {
+            ResetE2ETests.uuid = (String) invocation.getArgument(0);
+            return null;
+          }
+        })
+        .when(mailService)
+        .sendResetPwMail(anyString(), anyList());
+
     CertEmailDto dto = new CertEmailDto(email);
-    
+
     given()
         .contentType("application/json")
         .body(this.objToJson(dto))


### PR DESCRIPTION
> #44 참고

**PR 설명**
메인서버에 있는 프로필 아이콘 업로드 서비스를 MQ로 연결하였습니다.

**개발된 기능**
- 회원가입시 프로필 이미지 연동 기능을 MQ로 이전

**레퍼런스**
- https://kimseunghyun76.tistory.com/428